### PR TITLE
Add content props, #8

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npx commitlint --edit $1

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,5 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+yarn test:ci
+yarn prettier

--- a/dev/src/App.svelte
+++ b/dev/src/App.svelte
@@ -18,6 +18,7 @@
 		<div
 			use:useTooltip={{
 				position: tooltipPosition,
+				content: 'Test',
 				contentSelector: '.tooltip__button',
 				contentClone: false,
 				contentActions: {
@@ -28,7 +29,7 @@
 						closeOnCallback: true,
 					},
 				},
-				contentClassName: useCustomTooltipClass ? 'tooltip' : null,
+				containerClassName: useCustomTooltipClass ? 'tooltip' : null,
 				disabled: isTooltipDisabled,
 				animated: animateTooltip,
 				animationEnterClassName: useCustomAnimationEnterClass ? 'tooltip-enter' : null,

--- a/dev/src/App.svelte
+++ b/dev/src/App.svelte
@@ -9,7 +9,7 @@
 	let useCustomAnimationEnterClass = false
 	let useCustomAnimationLeaveClass = false
 
-	const _onTooltipClick = (arg, event) => {
+	const _onTooltipClick = (arg) => {
 		console.log(arg)
 	}
 </script>
@@ -20,7 +20,7 @@
 			use:useTooltip={{
 				position: tooltipPosition,
 				content: textContent,
-				contentSelector: !textContent?.length ? '.tooltip__button' : null,
+				contentSelector: !textContent?.length ? '.tooltip__content' : null,
 				contentClone: true,
 				contentActions: {
 					'*': {
@@ -40,15 +40,20 @@
 		>
 			Hover me
 		</div>
-		<span class="tooltip__button">Hi! I'm a fancy tooltip!</span>
 		<form class="settings__form">
 			<h1>Settings</h1>
-            <fieldset>
-                <label>
-                    Text Content:
-                    <input type="text" bind:value={textContent} />
-                </label>
-            </fieldset>
+			<fieldset>
+				<label>
+					Default Tooltip Content:
+					<span class="tooltip__content">Hi! I'm a <i>fancy</i> <strong>tooltip</strong>!</span>
+				</label>
+			</fieldset>
+			<fieldset>
+				<label>
+					Tooltip Text Content:
+					<input type="text" bind:value={textContent} />
+				</label>
+			</fieldset>
 			<fieldset>
 				<label>
 					Use Custom Tooltip Class:
@@ -125,6 +130,11 @@
 		cursor: pointer;
 		background-color: black;
 		color: white;
+	}
+
+	.tooltip__content {
+		background-color: yellow;
+		color: black;
 	}
 
 	.settings__form {

--- a/dev/src/App.svelte
+++ b/dev/src/App.svelte
@@ -1,8 +1,9 @@
 <script>
 	import { useTooltip } from '../../src'
 
-	let tooltipPosition = 'top'
+	let textContent = null
 	let useCustomTooltipClass = false
+	let tooltipPosition = 'top'
 	let isTooltipDisabled = false
 	let animateTooltip = false
 	let useCustomAnimationEnterClass = false
@@ -18,9 +19,9 @@
 		<div
 			use:useTooltip={{
 				position: tooltipPosition,
-				content: 'Test',
-				contentSelector: '.tooltip__button',
-				contentClone: false,
+				content: textContent,
+				contentSelector: !textContent?.length ? '.tooltip__button' : null,
+				contentClone: true,
 				contentActions: {
 					'*': {
 						eventType: 'click',
@@ -42,6 +43,12 @@
 		<span class="tooltip__button">Hi! I'm a fancy tooltip!</span>
 		<form class="settings__form">
 			<h1>Settings</h1>
+            <fieldset>
+                <label>
+                    Text Content:
+                    <input type="text" bind:value={textContent} />
+                </label>
+            </fieldset>
 			<fieldset>
 				<label>
 					Use Custom Tooltip Class:

--- a/package.json
+++ b/package.json
@@ -4,13 +4,7 @@
 	"author": "Vincent Le Badezet <v.lebadezet@untemps.net>",
 	"license": "MIT",
 	"description": "Svelte action to display a tooltip",
-	"keywords": [
-		"tooltip",
-		"svelte",
-		"svelte-action",
-		"action",
-		"javascript"
-	],
+	"keywords": ["tooltip", "svelte", "svelte-action", "action", "javascript"],
 	"private": false,
 	"publishConfig": {
 		"access": "public"
@@ -18,17 +12,15 @@
 	"main": "dist/index.js",
 	"module": "dist/index.es.js",
 	"svelte": "dist/index.js",
-	"files": [
-		"dist"
-	],
+	"files": ["dist"],
 	"devDependencies": {
 		"@babel/cli": "^7.12.10",
 		"@babel/core": "^7.12.10",
 		"@babel/plugin-proposal-class-properties": "^7.12.1",
 		"@babel/plugin-transform-runtime": "^7.12.10",
 		"@babel/preset-env": "^7.12.11",
-		"@commitlint/cli": "^14.1.0",
-		"@commitlint/config-conventional": "^14.1.0",
+		"@commitlint/cli": "^16.1.0",
+		"@commitlint/config-conventional": "^16.0.0",
 		"@rollup/plugin-babel": "^5.2.2",
 		"@rollup/plugin-commonjs": "^21.0.1",
 		"@rollup/plugin-node-resolve": "^13.0.6",
@@ -68,24 +60,11 @@
 		"moduleNameMapper": {
 			"\\.(css|less|scss)$": "identity-obj-proxy"
 		},
-		"moduleFileExtensions": [
-			"js",
-			"svelte"
-		],
-		"setupFilesAfterEnv": [
-			"<rootDir>/jest/jest.setup.js"
-		]
-	},
-	"husky": {
-		"hooks": {
-			"pre-commit": "yarn test:ci && yarn prettier",
-			"commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
-		}
+		"moduleFileExtensions": ["js", "svelte"],
+		"setupFilesAfterEnv": ["<rootDir>/jest/jest.setup.js"]
 	},
 	"release": {
-		"branches": [
-			"main"
-		],
+		"branches": ["main"],
 		"plugins": [
 			[
 				"@semantic-release/commit-analyzer",

--- a/src/Tooltip.js
+++ b/src/Tooltip.js
@@ -1,0 +1,241 @@
+import {DOMObserver} from '@untemps/dom-observer'
+
+class Tooltip {
+	static #instances = []
+	static get GAP() {
+		return 10
+	}
+	
+	#observer = null
+	
+	#tooltip = null
+	
+	#target = null
+	#content = null
+	#contentSelector = null
+	#contentActions = null
+	#contentClone = false
+	#containerClassName = null
+	#position = null
+	#animated = false
+	#animationEnterClassName = null
+	#animationLeaveClassName = null
+	
+	#events = []
+	
+	#boundEnterHandler = null
+	#boundLeaveHandler = null
+	
+	constructor(
+		target,
+		content,
+		contentSelector,
+		contentClone,
+		contentActions,
+		containerClassName,
+		position,
+		animated,
+		animationEnterClassName,
+		animationLeaveClassName,
+		disabled
+	) {
+		this.#target = target
+		this.#content = content
+		this.#contentSelector = contentSelector
+		this.#contentActions = contentActions
+		this.#contentClone = contentClone
+		this.#position = position
+		this.#animated = animated
+		this.#animationEnterClassName = animationEnterClassName || '__tooltip-enter'
+		this.#animationLeaveClassName = animationLeaveClassName || '__tooltip-leave'
+		
+		this.#target.title = ''
+		this.#target.setAttribute('style', 'position: relative')
+		
+		this.#tooltip = document.createElement('div')
+		this.#tooltip.id = 'tooltip'
+		
+		this.#observer = new DOMObserver()
+		if(this.#contentSelector) {
+			this.#observer
+				.wait(this.#contentSelector, null, { events: [DOMObserver.EXIST, DOMObserver.ADD] })
+				.then(({ node }) => {
+					const child = this.#contentClone ? node.cloneNode(true) : node
+					this.#tooltip.appendChild(child)
+				})
+		}
+		
+		this.#tooltip?.setAttribute('class', this.#containerClassName || `__tooltip __tooltip-${this.#position}`)
+		
+		disabled ? this.#disable() : this.#enable()
+		
+		Tooltip.#instances.push(this)
+	}
+	
+	static destroy() {
+		Tooltip.#instances.forEach((instance) => {
+			instance.destroy()
+		})
+		Tooltip.#instances = []
+	}
+	
+	update(content, contentSelector, contentClone, contentActions, containerClassName, position, animated, animationEnterClassName, animationLeaveClassName, disabled) {
+		this.#content = content
+		this.#contentSelector = contentSelector
+		this.#contentClone = contentClone
+		this.#contentActions = contentActions
+		this.#containerClassName = containerClassName
+		this.#position = position
+		this.#animated = animated
+		this.#animationEnterClassName = animationEnterClassName || '__tooltip-enter'
+		this.#animationLeaveClassName = animationLeaveClassName || '__tooltip-leave'
+		
+		this.#observer
+			.wait(this.#contentSelector, null, { events: [DOMObserver.EXIST, DOMObserver.ADD] })
+			.then(({ node }) => {
+				this.#tooltip.innerHTML = ''
+				const child = this.#contentClone ? node.cloneNode(true) : node
+				this.#tooltip.appendChild(child)
+			})
+		
+		this.#tooltip?.setAttribute('class', this.#containerClassName || `__tooltip __tooltip-${this.#position}`)
+		
+		if (!disabled && !this.#boundEnterHandler) {
+			this.#enable()
+		} else if (disabled && !!this.#boundEnterHandler) {
+			this.#disable()
+		}
+	}
+	
+	destroy() {
+		this.#removeContainerFromTarget()
+		
+		this.#disable()
+	}
+	
+	#enable() {
+		this.#boundEnterHandler = this.#onTargetEnter.bind(this)
+		this.#boundLeaveHandler = this.#onTargetLeave.bind(this)
+		
+		this.#target.addEventListener('mouseenter', this.#boundEnterHandler)
+		this.#target.addEventListener('mouseleave', this.#boundLeaveHandler)
+	}
+	
+	#disable() {
+		this.#target.removeEventListener('mouseenter', this.#boundEnterHandler)
+		this.#target.removeEventListener('mouseleave', this.#boundLeaveHandler)
+		
+		this.#boundEnterHandler = null
+		this.#boundLeaveHandler = null
+	}
+	
+	async #appendContainerToTarget() {
+		if (this.#animated) {
+			await this.#manageTransition(1)
+		}
+		
+		this.#target.appendChild(this.#tooltip)
+		
+		if (this.#contentActions) {
+			Object.entries(this.#contentActions).forEach(([key, { eventType, callback, callbackParams, closeOnCallback }]) => {
+				const trigger = key === '*' ? this.#tooltip : this.#tooltip.querySelector(key)
+				if (trigger) {
+					const listener = (event) => {
+						callback?.apply(null, [...callbackParams, event])
+						if (closeOnCallback) {
+							this.#removeContainerFromTarget()
+						}
+					}
+					trigger.addEventListener(eventType, listener)
+					this.#events.push({ trigger, eventType, listener })
+				}
+			})
+		}
+	}
+	
+	async #removeContainerFromTarget() {
+		if (this.#animated) {
+			await this.#manageTransition(0)
+		}
+		
+		this.#tooltip.remove()
+		
+		this.#events.forEach(({ trigger, eventType, listener }) => trigger.removeEventListener(eventType, listener))
+		this.#events = []
+	}
+	
+	#manageTransition(direction) {
+		return new Promise((resolve) => {
+			let classToAdd, classToRemove
+			switch (direction) {
+				case 1: {
+					classToAdd = this.#animationEnterClassName
+					classToRemove = this.#animationLeaveClassName
+					break
+				}
+				default: {
+					classToAdd = this.#animationLeaveClassName
+					classToRemove = this.#animationEnterClassName
+				}
+			}
+			this.#tooltip.classList.add(classToAdd)
+			this.#tooltip.classList.remove(classToRemove)
+			
+			if (direction === 1) {
+				resolve()
+			}
+			
+			const onTransitionEnd = () => {
+				this.#tooltip.removeEventListener('animationend', onTransitionEnd)
+				this.#tooltip.classList.remove(classToAdd)
+				resolve()
+			}
+			this.#tooltip.addEventListener('animationend', onTransitionEnd)
+		})
+	}
+	
+	async #onTargetEnter() {
+		console.log('ok')
+		await this.#appendContainerToTarget()
+		
+		this.#observer.wait(`#tooltip`, null, { events: [DOMObserver.EXIST] }).then(({ node }) => {
+			const { width: targetWidth, height: targetHeight } = this.#target.getBoundingClientRect()
+			const { width: tooltipWidth, height: tooltipHeight } = this.#tooltip.getBoundingClientRect()
+			switch (this.#position) {
+				case 'left': {
+					this.#tooltip.style.top = `${-(tooltipHeight - targetHeight) >> 1}px`
+					this.#tooltip.style.bottom = null
+					this.#tooltip.style.left = `${-tooltipWidth - Tooltip.GAP}px`
+					this.#tooltip.style.right = null
+					break
+				}
+				case 'right': {
+					this.#tooltip.style.top = `${-(tooltipHeight - targetHeight) >> 1}px`
+					this.#tooltip.style.bottom = null
+					this.#tooltip.style.right = `${-tooltipWidth - Tooltip.GAP}px`
+					this.#tooltip.style.left = null
+					break
+				}
+				case 'bottom': {
+					this.#tooltip.style.left = `${-(tooltipWidth - targetWidth) >> 1}px`
+					this.#tooltip.style.right = null
+					this.#tooltip.style.bottom = `${-tooltipHeight - Tooltip.GAP}px`
+					this.#tooltip.style.top = null
+					break
+				}
+				default: {
+					this.#tooltip.style.left = `${-(tooltipWidth - targetWidth) >> 1}px`
+					this.#tooltip.style.right = null
+					this.#tooltip.style.top = `${-tooltipHeight - Tooltip.GAP}px`
+					this.#tooltip.style.bottom = null
+				}
+			}
+		})
+	}
+	
+	async #onTargetLeave() {
+		await this.#removeContainerFromTarget()
+	}
+}
+
+export default Tooltip

--- a/src/Tooltip.js
+++ b/src/Tooltip.js
@@ -7,8 +7,12 @@ class Tooltip {
 	}
 	
 	#observer = null
+	#events = []
 	
 	#tooltip = null
+	
+	#boundEnterHandler = null
+	#boundLeaveHandler = null
 	
 	#target = null
 	#content = null
@@ -20,11 +24,6 @@ class Tooltip {
 	#animated = false
 	#animationEnterClassName = null
 	#animationLeaveClassName = null
-	
-	#events = []
-	
-	#boundEnterHandler = null
-	#boundLeaveHandler = null
 	
 	constructor(
 		target,
@@ -63,6 +62,9 @@ class Tooltip {
 					const child = this.#contentClone ? node.cloneNode(true) : node
 					this.#tooltip.appendChild(child)
 				})
+		} else if(this.#content) {
+			const textNode = document.createTextNode(this.#content)
+			this.#tooltip.appendChild(textNode)
 		}
 		
 		this.#tooltip?.setAttribute('class', this.#containerClassName || `__tooltip __tooltip-${this.#position}`)
@@ -90,13 +92,20 @@ class Tooltip {
 		this.#animationEnterClassName = animationEnterClassName || '__tooltip-enter'
 		this.#animationLeaveClassName = animationLeaveClassName || '__tooltip-leave'
 		
-		this.#observer
-			.wait(this.#contentSelector, null, { events: [DOMObserver.EXIST, DOMObserver.ADD] })
-			.then(({ node }) => {
-				this.#tooltip.innerHTML = ''
-				const child = this.#contentClone ? node.cloneNode(true) : node
-				this.#tooltip.appendChild(child)
-			})
+		if(this.#contentSelector) {
+			this.#observer
+				.wait(this.#contentSelector, null, { events: [DOMObserver.EXIST, DOMObserver.ADD] })
+				.then(({ node }) => {
+					this.#tooltip.innerHTML = ''
+					const child = this.#contentClone ? node.cloneNode(true) : node
+					this.#tooltip.appendChild(child)
+				})
+		} else if(this.#content) {
+			this.#tooltip.innerHTML = ''
+			const textNode = document.createTextNode(this.#content)
+			this.#tooltip.appendChild(textNode)
+		}
+		
 		
 		this.#tooltip?.setAttribute('class', this.#containerClassName || `__tooltip __tooltip-${this.#position}`)
 		
@@ -195,7 +204,6 @@ class Tooltip {
 	}
 	
 	async #onTargetEnter() {
-		console.log('ok')
 		await this.#appendContainerToTarget()
 		
 		this.#observer.wait(`#tooltip`, null, { events: [DOMObserver.EXIST] }).then(({ node }) => {

--- a/src/Tooltip.js
+++ b/src/Tooltip.js
@@ -1,19 +1,20 @@
-import {DOMObserver} from '@untemps/dom-observer'
+import { DOMObserver } from '@untemps/dom-observer'
 
 class Tooltip {
-	static #instances = []
 	static get GAP() {
 		return 10
 	}
-	
+
+	static #instances = []
+
 	#observer = null
 	#events = []
-	
+
 	#tooltip = null
-	
+
 	#boundEnterHandler = null
 	#boundLeaveHandler = null
-	
+
 	#target = null
 	#content = null
 	#contentSelector = null
@@ -24,7 +25,14 @@ class Tooltip {
 	#animated = false
 	#animationEnterClassName = null
 	#animationLeaveClassName = null
-	
+
+	static destroy() {
+		Tooltip.#instances.forEach((instance) => {
+			instance.destroy()
+		})
+		Tooltip.#instances = []
+	}
+
 	constructor(
 		target,
 		content,
@@ -43,45 +51,41 @@ class Tooltip {
 		this.#contentSelector = contentSelector
 		this.#contentActions = contentActions
 		this.#contentClone = contentClone
+		this.#containerClassName = containerClassName
 		this.#position = position
 		this.#animated = animated
 		this.#animationEnterClassName = animationEnterClassName || '__tooltip-enter'
 		this.#animationLeaveClassName = animationLeaveClassName || '__tooltip-leave'
-		
+
+		this.#observer = new DOMObserver()
+
 		this.#target.title = ''
 		this.#target.setAttribute('style', 'position: relative')
-		
-		this.#tooltip = document.createElement('div')
-		this.#tooltip.id = 'tooltip'
-		
-		this.#observer = new DOMObserver()
-		if(this.#contentSelector) {
-			this.#observer
-				.wait(this.#contentSelector, null, { events: [DOMObserver.EXIST, DOMObserver.ADD] })
-				.then(({ node }) => {
-					const child = this.#contentClone ? node.cloneNode(true) : node
-					this.#tooltip.appendChild(child)
-				})
-		} else if(this.#content) {
-			const textNode = document.createTextNode(this.#content)
-			this.#tooltip.appendChild(textNode)
-		}
-		
-		this.#tooltip?.setAttribute('class', this.#containerClassName || `__tooltip __tooltip-${this.#position}`)
-		
-		disabled ? this.#disable() : this.#enable()
-		
+
+		this.#createTooltip()
+
+		disabled ? this.#disableTarget() : this.#enableTarget()
+
 		Tooltip.#instances.push(this)
 	}
-	
-	static destroy() {
-		Tooltip.#instances.forEach((instance) => {
-			instance.destroy()
-		})
-		Tooltip.#instances = []
-	}
-	
-	update(content, contentSelector, contentClone, contentActions, containerClassName, position, animated, animationEnterClassName, animationLeaveClassName, disabled) {
+
+	update(
+		content,
+		contentSelector,
+		contentClone,
+		contentActions,
+		containerClassName,
+		position,
+		animated,
+		animationEnterClassName,
+		animationLeaveClassName,
+		disabled
+	) {
+		const hasContentChanged = contentSelector !== this.#contentSelector || content !== this.#content
+		const hasContainerClassNameChanged = containerClassName !== this.#containerClassName
+		const hasToDisableTarget = disabled && this.#boundEnterHandler
+		const hasToEnableTarget = !disabled && !this.#boundEnterHandler
+
 		this.#content = content
 		this.#contentSelector = contentSelector
 		this.#contentClone = contentClone
@@ -91,89 +95,141 @@ class Tooltip {
 		this.#animated = animated
 		this.#animationEnterClassName = animationEnterClassName || '__tooltip-enter'
 		this.#animationLeaveClassName = animationLeaveClassName || '__tooltip-leave'
-		
-		if(this.#contentSelector) {
-			this.#observer
-				.wait(this.#contentSelector, null, { events: [DOMObserver.EXIST, DOMObserver.ADD] })
-				.then(({ node }) => {
-					this.#tooltip.innerHTML = ''
-					const child = this.#contentClone ? node.cloneNode(true) : node
-					this.#tooltip.appendChild(child)
-				})
-		} else if(this.#content) {
-			this.#tooltip.innerHTML = ''
-			const textNode = document.createTextNode(this.#content)
-			this.#tooltip.appendChild(textNode)
+
+		if (hasContentChanged) {
+			this.#removeTooltipFromTarget()
+
+			this.#createTooltip()
 		}
-		
-		
-		this.#tooltip?.setAttribute('class', this.#containerClassName || `__tooltip __tooltip-${this.#position}`)
-		
-		if (!disabled && !this.#boundEnterHandler) {
-			this.#enable()
-		} else if (disabled && !!this.#boundEnterHandler) {
-			this.#disable()
+
+		if (hasContainerClassNameChanged) {
+			this.#tooltip.className = this.#containerClassName || `__tooltip __tooltip-${this.#position}`
+		}
+
+		if (hasToDisableTarget) {
+			this.#disableTarget()
+		} else if (hasToEnableTarget) {
+			this.#enableTarget()
 		}
 	}
-	
+
 	destroy() {
-		this.#removeContainerFromTarget()
-		
-		this.#disable()
+		this.#removeTooltipFromTarget()
+
+		this.#disableTarget()
+
+		this.#observer?.clear()
+		this.#observer = null
 	}
-	
-	#enable() {
+
+	#enableTarget() {
 		this.#boundEnterHandler = this.#onTargetEnter.bind(this)
 		this.#boundLeaveHandler = this.#onTargetLeave.bind(this)
-		
+
 		this.#target.addEventListener('mouseenter', this.#boundEnterHandler)
 		this.#target.addEventListener('mouseleave', this.#boundLeaveHandler)
 	}
-	
-	#disable() {
+
+	#disableTarget() {
 		this.#target.removeEventListener('mouseenter', this.#boundEnterHandler)
 		this.#target.removeEventListener('mouseleave', this.#boundLeaveHandler)
-		
+
 		this.#boundEnterHandler = null
 		this.#boundLeaveHandler = null
 	}
-	
-	async #appendContainerToTarget() {
-		if (this.#animated) {
-			await this.#manageTransition(1)
-		}
-		
-		this.#target.appendChild(this.#tooltip)
-		
-		if (this.#contentActions) {
-			Object.entries(this.#contentActions).forEach(([key, { eventType, callback, callbackParams, closeOnCallback }]) => {
-				const trigger = key === '*' ? this.#tooltip : this.#tooltip.querySelector(key)
-				if (trigger) {
-					const listener = (event) => {
-						callback?.apply(null, [...callbackParams, event])
-						if (closeOnCallback) {
-							this.#removeContainerFromTarget()
-						}
-					}
-					trigger.addEventListener(eventType, listener)
-					this.#events.push({ trigger, eventType, listener })
-				}
-			})
+
+	#createTooltip() {
+		this.#tooltip = document.createElement('div')
+		this.#tooltip.className = this.#containerClassName || `__tooltip __tooltip-${this.#position}`
+
+		if (this.#contentSelector) {
+			this.#observer
+				.wait(this.#contentSelector, null, { events: [DOMObserver.EXIST, DOMObserver.ADD] })
+				.then(({ node }) => {
+					const child = this.#contentClone ? node.cloneNode(true) : node
+					this.#tooltip.appendChild(child)
+				})
+		} else if (this.#content) {
+			const child = document.createTextNode(this.#content)
+			this.#tooltip.appendChild(child)
 		}
 	}
-	
-	async #removeContainerFromTarget() {
-		if (this.#animated) {
-			await this.#manageTransition(0)
+
+	#positionTooltip() {
+		const { width: targetWidth, height: targetHeight } = this.#target.getBoundingClientRect()
+		const { width: tooltipWidth, height: tooltipHeight } = this.#tooltip.getBoundingClientRect()
+		switch (this.#position) {
+			case 'left': {
+				this.#tooltip.style.top = `${-(tooltipHeight - targetHeight) >> 1}px`
+				this.#tooltip.style.left = `${-tooltipWidth - Tooltip.GAP}px`
+				this.#tooltip.style.bottom = null
+				this.#tooltip.style.right = null
+				break
+			}
+			case 'right': {
+				this.#tooltip.style.top = `${-(tooltipHeight - targetHeight) >> 1}px`
+				this.#tooltip.style.right = `${-tooltipWidth - Tooltip.GAP}px`
+				this.#tooltip.style.bottom = null
+				this.#tooltip.style.left = null
+				break
+			}
+			case 'bottom': {
+				this.#tooltip.style.left = `${-(tooltipWidth - targetWidth) >> 1}px`
+				this.#tooltip.style.bottom = `${-tooltipHeight - Tooltip.GAP}px`
+				this.#tooltip.style.right = null
+				this.#tooltip.style.top = null
+				break
+			}
+			default: {
+				this.#tooltip.style.left = `${-(tooltipWidth - targetWidth) >> 1}px`
+				this.#tooltip.style.top = `${-tooltipHeight - Tooltip.GAP}px`
+				this.#tooltip.style.right = null
+				this.#tooltip.style.bottom = null
+			}
 		}
-		
+	}
+
+	async #appendTooltipToTarget() {
+		if (this.#animated) {
+			await this.#transitionTooltip(1)
+		}
+
+		this.#target.appendChild(this.#tooltip)
+		this.#observer.wait(this.#tooltip, null, { events: [DOMObserver.EXIST, DOMObserver.ADD] }).then(() => {
+			this.#positionTooltip()
+		})
+
+		if (this.#contentActions) {
+			Object.entries(this.#contentActions).forEach(
+				([key, { eventType, callback, callbackParams, closeOnCallback }]) => {
+					const trigger = key === '*' ? this.#tooltip : this.#tooltip.querySelector(key)
+					if (trigger) {
+						const listener = (event) => {
+							callback?.apply(null, [...callbackParams, event])
+							if (closeOnCallback) {
+								this.#removeTooltipFromTarget()
+							}
+						}
+						trigger.addEventListener(eventType, listener)
+						this.#events.push({ trigger, eventType, listener })
+					}
+				}
+			)
+		}
+	}
+
+	async #removeTooltipFromTarget() {
+		if (this.#animated) {
+			await this.#transitionTooltip(0)
+		}
+
 		this.#tooltip.remove()
-		
+
 		this.#events.forEach(({ trigger, eventType, listener }) => trigger.removeEventListener(eventType, listener))
 		this.#events = []
 	}
-	
-	#manageTransition(direction) {
+
+	#transitionTooltip(direction) {
 		return new Promise((resolve) => {
 			let classToAdd, classToRemove
 			switch (direction) {
@@ -189,11 +245,11 @@ class Tooltip {
 			}
 			this.#tooltip.classList.add(classToAdd)
 			this.#tooltip.classList.remove(classToRemove)
-			
+
 			if (direction === 1) {
 				resolve()
 			}
-			
+
 			const onTransitionEnd = () => {
 				this.#tooltip.removeEventListener('animationend', onTransitionEnd)
 				this.#tooltip.classList.remove(classToAdd)
@@ -202,47 +258,13 @@ class Tooltip {
 			this.#tooltip.addEventListener('animationend', onTransitionEnd)
 		})
 	}
-	
+
 	async #onTargetEnter() {
-		await this.#appendContainerToTarget()
-		
-		this.#observer.wait(`#tooltip`, null, { events: [DOMObserver.EXIST] }).then(({ node }) => {
-			const { width: targetWidth, height: targetHeight } = this.#target.getBoundingClientRect()
-			const { width: tooltipWidth, height: tooltipHeight } = this.#tooltip.getBoundingClientRect()
-			switch (this.#position) {
-				case 'left': {
-					this.#tooltip.style.top = `${-(tooltipHeight - targetHeight) >> 1}px`
-					this.#tooltip.style.bottom = null
-					this.#tooltip.style.left = `${-tooltipWidth - Tooltip.GAP}px`
-					this.#tooltip.style.right = null
-					break
-				}
-				case 'right': {
-					this.#tooltip.style.top = `${-(tooltipHeight - targetHeight) >> 1}px`
-					this.#tooltip.style.bottom = null
-					this.#tooltip.style.right = `${-tooltipWidth - Tooltip.GAP}px`
-					this.#tooltip.style.left = null
-					break
-				}
-				case 'bottom': {
-					this.#tooltip.style.left = `${-(tooltipWidth - targetWidth) >> 1}px`
-					this.#tooltip.style.right = null
-					this.#tooltip.style.bottom = `${-tooltipHeight - Tooltip.GAP}px`
-					this.#tooltip.style.top = null
-					break
-				}
-				default: {
-					this.#tooltip.style.left = `${-(tooltipWidth - targetWidth) >> 1}px`
-					this.#tooltip.style.right = null
-					this.#tooltip.style.top = `${-tooltipHeight - Tooltip.GAP}px`
-					this.#tooltip.style.bottom = null
-				}
-			}
-		})
+		await this.#appendTooltipToTarget()
 	}
-	
+
 	async #onTargetLeave() {
-		await this.#removeContainerFromTarget()
+		await this.#removeTooltipFromTarget()
 	}
 }
 

--- a/src/__tests__/useTooltip.test.js
+++ b/src/__tests__/useTooltip.test.js
@@ -4,7 +4,8 @@
 
 import { fireEvent } from '@testing-library/svelte'
 
-import useTooltip, { Tooltip } from '../useTooltip'
+import useTooltip from '../useTooltip'
+import Tooltip from '../Tooltip'
 
 describe('useTooltip', () => {
 	let target,
@@ -70,6 +71,13 @@ describe('useTooltip', () => {
 				await fireEvent.animationEnd(template.parentNode)
 				expect(template).not.toBeInTheDocument()
 			})
+
+			it('Disables tooltip', async () => {
+				action = useTooltip(target, { ...options, disabled: true })
+				await fireEvent.mouseOver(target) // fireEvent.mouseEnter only works if mouseOver is triggered before
+				await fireEvent.mouseEnter(target)
+				expect(template).not.toBeVisible()
+			})
 		})
 
 		describe('update', () => {
@@ -88,6 +96,28 @@ describe('useTooltip', () => {
 				await fireEvent.mouseEnter(target)
 				expect(newTemplate).toBeVisible()
 			})
+
+			it('Disables tooltip', async () => {
+				action = useTooltip(target, options)
+				action.update({
+					...options,
+					disabled: true,
+				})
+				await fireEvent.mouseOver(target) // fireEvent.mouseEnter only works if mouseOver is triggered before
+				await fireEvent.mouseEnter(target)
+				expect(template).not.toBeVisible()
+			})
+
+			it('Enables tooltip', async () => {
+				action = useTooltip(target, { ...options, disabled: true })
+				action.update({
+					...options,
+					disabled: false,
+				})
+				await fireEvent.mouseOver(target) // fireEvent.mouseEnter only works if mouseOver is triggered before
+				await fireEvent.mouseEnter(target)
+				expect(template).toBeVisible()
+			})
 		})
 	})
 
@@ -98,6 +128,25 @@ describe('useTooltip', () => {
 			await fireEvent.mouseOver(target) // fireEvent.mouseEnter only works if mouseOver is triggered before
 			await fireEvent.mouseEnter(target)
 			expect(template).not.toBeVisible()
+		})
+	})
+
+	describe('useTooltip content', () => {
+		it('Displays text content', async () => {
+			const content = 'Foo'
+			action = useTooltip(target, { ...options, contentSelector: null, content })
+			await fireEvent.mouseOver(target) // fireEvent.mouseEnter only works if mouseOver is triggered before
+			await fireEvent.mouseEnter(target)
+			expect(target).toHaveTextContent(content)
+		})
+
+		it('Displays content element over text', async () => {
+			const content = 'Foo'
+			action = useTooltip(target, { ...options, content })
+			await fireEvent.mouseOver(target) // fireEvent.mouseEnter only works if mouseOver is triggered before
+			await fireEvent.mouseEnter(target)
+			expect(target).not.toHaveTextContent(content)
+			expect(template).toBeInTheDocument()
 		})
 	})
 
@@ -164,7 +213,7 @@ describe('useTooltip', () => {
 		})
 	})
 
-	describe('useTooltip props: contentClassName', () => {
+	describe('useTooltip props: containerClassName', () => {
 		it('Sets tooltip default class', async () => {
 			action = useTooltip(target, options)
 			await fireEvent.mouseOver(target) // fireEvent.mouseEnter only works if mouseOver is triggered before
@@ -172,16 +221,23 @@ describe('useTooltip', () => {
 			expect(template.parentNode).toHaveClass('__tooltip')
 		})
 
-		it('Sets new tooltip class after update', async () => {
+		it('Updates tooltip class', async () => {
 			action = useTooltip(target, options)
 			await fireEvent.mouseOver(target) // fireEvent.mouseEnter only works if mouseOver is triggered before
 			await fireEvent.mouseEnter(target)
 			expect(template.parentNode).toHaveClass('__tooltip')
 			action.update({
 				...options,
-				contentClassName: 'foo',
+				containerClassName: '__custom-tooltip',
 			})
-			expect(template.parentNode).toHaveClass('foo')
+			expect(template.parentNode).toHaveClass('__custom-tooltip')
+		})
+
+		it('Sets tooltip custom class', async () => {
+			action = useTooltip(target, { ...options, containerClassName: '__custom-tooltip' })
+			await fireEvent.mouseOver(target) // fireEvent.mouseEnter only works if mouseOver is triggered before
+			await fireEvent.mouseEnter(target)
+			expect(template.parentNode).toHaveClass('__custom-tooltip')
 		})
 	})
 
@@ -199,6 +255,67 @@ describe('useTooltip', () => {
 			await fireEvent.mouseOver(target) // fireEvent.mouseEnter only works if mouseOver is triggered before
 			await fireEvent.mouseEnter(target)
 			expect(template).not.toBeVisible()
+		})
+	})
+
+	describe('useTooltip props: position', () => {
+		it('Updates tooltip position: from left to right', async () => {
+			action = useTooltip(target, { ...options, position: 'left' })
+			await fireEvent.mouseOver(target) // fireEvent.mouseEnter only works if mouseOver is triggered before
+			await fireEvent.mouseEnter(target)
+
+			const left = template.parentNode.style.left
+			const top = template.parentNode.style.top
+
+			action.update({
+				...options,
+				position: 'right',
+			})
+			await fireEvent.mouseOver(target) // fireEvent.mouseEnter only works if mouseOver is triggered before
+			await fireEvent.mouseEnter(target)
+
+			expect(template.parentNode.style.left).not.toBe(left)
+			expect(template.parentNode.style.top).toBe(top)
+		})
+
+		it('Updates tooltip position: from top to bottom', async () => {
+			action = useTooltip(target, options)
+			await fireEvent.mouseOver(target) // fireEvent.mouseEnter only works if mouseOver is triggered before
+			await fireEvent.mouseEnter(target)
+
+			const left = template.parentNode.style.left
+			const top = template.parentNode.style.top
+			const bottom = template.parentNode.style.bottom
+
+			action.update({
+				...options,
+				position: 'bottom',
+			})
+			await fireEvent.mouseOver(target) // fireEvent.mouseEnter only works if mouseOver is triggered before
+			await fireEvent.mouseEnter(target)
+
+			expect(template.parentNode.style.left).toBe(left)
+			expect(template.parentNode.style.top).not.toBe(top)
+			expect(template.parentNode.style.bottom).not.toBe(bottom)
+		})
+
+		it('Updates tooltip position: from top to left', async () => {
+			action = useTooltip(target, options)
+			await fireEvent.mouseOver(target) // fireEvent.mouseEnter only works if mouseOver is triggered before
+			await fireEvent.mouseEnter(target)
+
+			const left = template.parentNode.style.left
+			const top = template.parentNode.style.top
+
+			action.update({
+				...options,
+				position: 'left',
+			})
+			await fireEvent.mouseOver(target) // fireEvent.mouseEnter only works if mouseOver is triggered before
+			await fireEvent.mouseEnter(target)
+
+			expect(template.parentNode.style.left).not.toBe(left)
+			expect(template.parentNode.style.top).not.toBe(top)
 		})
 	})
 })

--- a/src/useTooltip.css
+++ b/src/useTooltip.css
@@ -3,7 +3,7 @@
 	z-index: 9999;
 	max-width: 100%;
 	background-color: black;
-	color: #fff;
+	color: white;
 	text-align: center;
 	border-radius: 6px;
 	padding: 0.5rem;

--- a/src/useTooltip.js
+++ b/src/useTooltip.js
@@ -1,301 +1,65 @@
-import { DOMObserver } from '@untemps/dom-observer'
+import Tooltip from './Tooltip'
 
 import './useTooltip.css'
 
 const useTooltip = (
 	node,
 	{
-		position,
+		content,
 		contentSelector,
 		contentClone,
 		contentActions,
-		contentClassName,
+		containerClassName,
+		position,
 		animated,
 		animationEnterClassName,
 		animationLeaveClassName,
 		disabled,
 	}
 ) => {
-	Tooltip.init(contentSelector, contentClone)
-
 	const tooltip = new Tooltip(
 		node,
-		position,
-		disabled,
+		content,
+		contentSelector,
+		contentClone,
 		contentActions,
-		contentClassName,
+		containerClassName,
+		position,
 		animated,
 		animationEnterClassName,
-		animationLeaveClassName
+		animationLeaveClassName,
+		disabled
 	)
 
 	return {
 		update: ({
-			position: newPosition,
+			content: newContent,
 			contentSelector: newContentSelector,
 			contentClone: newContentClone,
 			contentActions: newContentActions,
-			contentClassName: newContentClassName,
-			disabled: newDisabled,
+			containerClassName: newContainerClassName,
+			position: newPosition,
 			animated: newAnimated,
 			animationEnterClassName: newAnimationEnterClassName,
 			animationLeaveClassName: newAnimationLeaveClassName,
+			disabled: newDisabled,
 		}) => {
-			Tooltip.update(newContentSelector, newContentClone)
-
 			tooltip.update(
-				newPosition,
-				newDisabled,
+				newContent,
+				newContentSelector,
+				newContentClone,
 				newContentActions,
-				newContentClassName,
+				newContainerClassName,
+				newPosition,
 				newAnimated,
 				newAnimationEnterClassName,
-				newAnimationLeaveClassName
+				newAnimationLeaveClassName,
+				newDisabled
 			)
 		},
 		destroy: () => {
 			tooltip.destroy()
 		},
-	}
-}
-
-export class Tooltip {
-	static #isInitialized = false
-	static #observer = null
-	static #tooltip = null
-	static #contentSelector = null
-	static #instances = []
-
-	#target = null
-	#position = null
-	#actions = null
-	#animated = false
-	#animationEnterClassName = null
-	#animationLeaveClassName = null
-	#container = null
-	#events = []
-
-	#boundEnterHandler = null
-	#boundLeaveHandler = null
-
-	constructor(
-		target,
-		position,
-		disabled,
-		actions,
-		className,
-		animated,
-		animationEnterClassName,
-		animationLeaveClassName
-	) {
-		this.#target = target
-		this.#position = position
-		this.#actions = actions
-		this.#container = Tooltip.#tooltip
-		this.#animated = animated
-		this.#animationEnterClassName = animationEnterClassName || '__tooltip-enter'
-		this.#animationLeaveClassName = animationLeaveClassName || '__tooltip-leave'
-
-		this.#container?.setAttribute('class', className || `__tooltip __tooltip-${this.#position}`)
-
-		disabled ? this.#disable() : this.#enable()
-
-		this.#target.title = ''
-		this.#target.setAttribute('style', 'position: relative')
-
-		Tooltip.#instances.push(this)
-	}
-
-	static init(contentSelector, contentClone = false) {
-		if (!Tooltip.#isInitialized) {
-			Tooltip.#tooltip = document.createElement('div')
-			Tooltip.#tooltip.id = 'tooltip'
-
-			Tooltip.#observer = new DOMObserver()
-			Tooltip.#observer
-				.wait(contentSelector, null, { events: [DOMObserver.EXIST, DOMObserver.ADD] })
-				.then(({ node }) => {
-					const child = contentClone ? node.cloneNode(true) : node
-					Tooltip.#tooltip.appendChild(child)
-				})
-
-			Tooltip.#contentSelector = contentSelector
-			Tooltip.#isInitialized = true
-		}
-	}
-
-	static update(contentSelector, contentClone = false) {
-		if (Tooltip.#isInitialized && contentSelector !== Tooltip.#contentSelector) {
-			Tooltip.#contentSelector = contentSelector
-
-			Tooltip.#observer
-				.wait(contentSelector, null, { events: [DOMObserver.EXIST, DOMObserver.ADD] })
-				.then(({ node }) => {
-					Tooltip.#tooltip.innerHTML = ''
-					const child = contentClone ? node.cloneNode(true) : node
-					Tooltip.#tooltip.appendChild(child)
-				})
-		}
-	}
-
-	static destroy() {
-		Tooltip.#instances.forEach((instance) => {
-			instance.destroy()
-		})
-		Tooltip.#instances = []
-
-		Tooltip.#tooltip?.parentNode?.removeChild(Tooltip.#tooltip)
-		Tooltip.#tooltip = null
-
-		Tooltip.#contentSelector = null
-
-		Tooltip.#observer.clear()
-		Tooltip.#isInitialized = false
-	}
-
-	update(position, disabled, actions, className, animated, animationEnterClassName, animationLeaveClassName) {
-		this.#position = position
-		this.#actions = actions
-		this.#animated = animated
-		this.#animationEnterClassName = animationEnterClassName || '__tooltip-enter'
-		this.#animationLeaveClassName = animationLeaveClassName || '__tooltip-leave'
-
-		this.#container?.setAttribute('class', className || `__tooltip __tooltip-${this.#position}`)
-
-		if (!disabled && !this.#boundEnterHandler) {
-			this.#enable()
-		} else if (disabled && !!this.#boundEnterHandler) {
-			this.#disable()
-		}
-	}
-
-	destroy() {
-		this.#removeContainerFromTarget()
-
-		this.#disable()
-	}
-
-	#enable() {
-		this.#boundEnterHandler = this.#onTargetEnter.bind(this)
-		this.#boundLeaveHandler = this.#onTargetLeave.bind(this)
-
-		this.#target.addEventListener('mouseenter', this.#boundEnterHandler)
-		this.#target.addEventListener('mouseleave', this.#boundLeaveHandler)
-	}
-
-	#disable() {
-		this.#target.removeEventListener('mouseenter', this.#boundEnterHandler)
-		this.#target.removeEventListener('mouseleave', this.#boundLeaveHandler)
-
-		this.#boundEnterHandler = null
-		this.#boundLeaveHandler = null
-	}
-
-	async #appendContainerToTarget() {
-		if (this.#animated) {
-			await this.#manageTransition(1)
-		}
-
-		this.#target.appendChild(this.#container)
-
-		if (this.#actions) {
-			Object.entries(this.#actions).forEach(([key, { eventType, callback, callbackParams, closeOnCallback }]) => {
-				const trigger = key === '*' ? this.#container : this.#container.querySelector(key)
-				if (trigger) {
-					const listener = (event) => {
-						callback?.apply(null, [...callbackParams, event])
-						if (closeOnCallback) {
-							this.#removeContainerFromTarget()
-						}
-					}
-					trigger.addEventListener(eventType, listener)
-					this.#events.push({ trigger, eventType, listener })
-				}
-			})
-		}
-	}
-
-	async #removeContainerFromTarget() {
-		if (this.#animated) {
-			await this.#manageTransition(0)
-		}
-
-		this.#container.remove()
-
-		this.#events.forEach(({ trigger, eventType, listener }) => trigger.removeEventListener(eventType, listener))
-		this.#events = []
-	}
-
-	#manageTransition(direction) {
-		return new Promise((resolve) => {
-			let classToAdd, classToRemove
-			switch (direction) {
-				case 1: {
-					classToAdd = this.#animationEnterClassName
-					classToRemove = this.#animationLeaveClassName
-					break
-				}
-				default: {
-					classToAdd = this.#animationLeaveClassName
-					classToRemove = this.#animationEnterClassName
-				}
-			}
-			this.#container.classList.add(classToAdd)
-			this.#container.classList.remove(classToRemove)
-
-			if (direction === 1) {
-				resolve()
-			}
-
-			const onTransitionEnd = () => {
-				this.#container.removeEventListener('animationend', onTransitionEnd)
-				this.#container.classList.remove(classToAdd)
-				resolve()
-			}
-			this.#container.addEventListener('animationend', onTransitionEnd)
-		})
-	}
-
-	async #onTargetEnter() {
-		await this.#appendContainerToTarget()
-
-		Tooltip.#observer.wait(`#tooltip`, null, { events: [DOMObserver.EXIST] }).then(({ node }) => {
-			const { width: targetWidth, height: targetHeight } = this.#target.getBoundingClientRect()
-			const { width: tooltipWidth, height: tooltipHeight } = this.#container.getBoundingClientRect()
-			switch (this.#position) {
-				case 'left': {
-					this.#container.style.top = `${-(tooltipHeight - targetHeight) >> 1}px`
-					this.#container.style.bottom = null
-					this.#container.style.left = `${-tooltipWidth - 6}px`
-					this.#container.style.right = null
-					break
-				}
-				case 'right': {
-					this.#container.style.top = `${-(tooltipHeight - targetHeight) >> 1}px`
-					this.#container.style.bottom = null
-					this.#container.style.right = `${-tooltipWidth - 6}px`
-					this.#container.style.left = null
-					break
-				}
-				case 'bottom': {
-					this.#container.style.left = `${-(tooltipWidth - targetWidth) >> 1}px`
-					this.#container.style.right = null
-					this.#container.style.bottom = `${-tooltipHeight - 6}px`
-					this.#container.style.top = null
-					break
-				}
-				default: {
-					this.#container.style.left = `${-(tooltipWidth - targetWidth) >> 1}px`
-					this.#container.style.right = null
-					this.#container.style.top = `${-tooltipHeight - 6}px`
-					this.#container.style.bottom = null
-				}
-			}
-		})
-	}
-
-	async #onTargetLeave() {
-		await this.#removeContainerFromTarget()
 	}
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -954,155 +954,168 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@commitlint/cli@^14.1.0":
-  version "14.1.0"
-  resolved "https://registry.yarnpkg.com/@commitlint/cli/-/cli-14.1.0.tgz#7b657a955ed22f3df348ba9afa6ce5a5121ff7eb"
-  integrity sha512-Orq62jkl9qAGvjFqhehtAqjGY/duJ8hIRPPIHmGR2jIB96D4VTmazS3ZvqJz2Q9kKr61mLAk/171zm0FVzQCYA==
+"@commitlint/cli@^16.1.0":
+  version "16.1.0"
+  resolved "https://registry.yarnpkg.com/@commitlint/cli/-/cli-16.1.0.tgz#022ad86008374b02974c9f3faf86affb785f4574"
+  integrity sha512-x5L1knvA3isRWBRVQx+Q6D45pA9139a2aZQYpxkljMG0dj4UHZkCnsYWpnGalxPxASI7nrI0KedKfS2YeQ55cQ==
   dependencies:
-    "@commitlint/format" "^14.1.0"
-    "@commitlint/lint" "^14.1.0"
-    "@commitlint/load" "^14.1.0"
-    "@commitlint/read" "^14.0.0"
-    "@commitlint/types" "^14.0.0"
+    "@commitlint/format" "^16.0.0"
+    "@commitlint/lint" "^16.0.0"
+    "@commitlint/load" "^16.1.0"
+    "@commitlint/read" "^16.0.0"
+    "@commitlint/types" "^16.0.0"
     lodash "^4.17.19"
     resolve-from "5.0.0"
     resolve-global "1.0.0"
     yargs "^17.0.0"
 
-"@commitlint/config-conventional@^14.1.0":
-  version "14.1.0"
-  resolved "https://registry.yarnpkg.com/@commitlint/config-conventional/-/config-conventional-14.1.0.tgz#29e386ef200fa72d43418153ab1c490c89024dee"
-  integrity sha512-JuhCqkEv8jyqmd54EpXPsQFpYc/8k7sfP1UziRdEvZSJUCLxz+8Pk4cNS0oF1BtjaWO7ITgXPlIZg47PyApGmg==
+"@commitlint/config-conventional@^16.0.0":
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/@commitlint/config-conventional/-/config-conventional-16.0.0.tgz#f42d9e1959416b5e691c8b5248fc2402adb1fc03"
+  integrity sha512-mN7J8KlKFn0kROd+q9PB01sfDx/8K/R25yITspL1No8PB4oj9M1p77xWjP80hPydqZG9OvQq+anXK3ZWeR7s3g==
   dependencies:
     conventional-changelog-conventionalcommits "^4.3.1"
 
-"@commitlint/ensure@^14.1.0":
-  version "14.1.0"
-  resolved "https://registry.yarnpkg.com/@commitlint/ensure/-/ensure-14.1.0.tgz#b58b2ffe2bc95be143ed8f188721b97df1043ba5"
-  integrity sha512-xrYvFdqVepT3XA1BmSh88eKbvYKtLuQu98QLfgxVmwS99Kj3yW0sT3D7jGvNsynbIx2dhbXofDyubf/DKkpFrQ==
+"@commitlint/config-validator@^16.1.0":
+  version "16.1.0"
+  resolved "https://registry.yarnpkg.com/@commitlint/config-validator/-/config-validator-16.1.0.tgz#410979f713ed55cbb85504d46295c1fd2419dc4d"
+  integrity sha512-2cHeZPNTuf1JWbMqyA46MkExor5HMSgv8JrdmzEakUbJHUreh35/wN00FJf57qGs134exQW2thiSQ1IJUsVx2Q==
   dependencies:
-    "@commitlint/types" "^14.0.0"
+    "@commitlint/types" "^16.0.0"
+    ajv "^6.12.6"
+
+"@commitlint/ensure@^16.0.0":
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/@commitlint/ensure/-/ensure-16.0.0.tgz#fdac1e60a944a1993deb33b5e8454c559abe9866"
+  integrity sha512-WdMySU8DCTaq3JPf0tZFCKIUhqxaL54mjduNhu8v4D2AMUVIIQKYMGyvXn94k8begeW6iJkTf9cXBArayskE7Q==
+  dependencies:
+    "@commitlint/types" "^16.0.0"
     lodash "^4.17.19"
 
-"@commitlint/execute-rule@^14.0.0":
-  version "14.0.0"
-  resolved "https://registry.yarnpkg.com/@commitlint/execute-rule/-/execute-rule-14.0.0.tgz#3ba45fc255286e3180f89ed4e9ac1ef237160734"
-  integrity sha512-Hh/HLpCBDlrD3Rx2x2pDBx6CU+OtVqGXh7mbFpNihAVx6B0zyZqm/vv0cdwdhfGW5OEn1BhCqHf1ZOvL/DwdWA==
+"@commitlint/execute-rule@^16.0.0":
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/@commitlint/execute-rule/-/execute-rule-16.0.0.tgz#824e11ba5b208c214a474ae52a51780d32d31ebc"
+  integrity sha512-8edcCibmBb386x5JTHSPHINwA5L0xPkHQFY8TAuDEt5QyRZY/o5DF8OPHSa5Hx2xJvGaxxuIz4UtAT6IiRDYkw==
 
-"@commitlint/format@^14.1.0":
-  version "14.1.0"
-  resolved "https://registry.yarnpkg.com/@commitlint/format/-/format-14.1.0.tgz#09b4081bdcb02163496bfcece98f9d4606238bc5"
-  integrity sha512-sF6engqqHjvxGctWRKjFs/HQeNowlpbVmmoP481b2UMQnVQnjjfXJvQsoLpaqFUvgc2sHM4L85F8BmAw+iHG1w==
+"@commitlint/format@^16.0.0":
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/@commitlint/format/-/format-16.0.0.tgz#6a6fb2c1e6460aff63cc6eca30a7807a96b0ce73"
+  integrity sha512-9yp5NCquXL1jVMKL0ZkRwJf/UHdebvCcMvICuZV00NQGYSAL89O398nhqrqxlbjBhM5EZVq0VGcV5+7r3D4zAA==
   dependencies:
-    "@commitlint/types" "^14.0.0"
+    "@commitlint/types" "^16.0.0"
     chalk "^4.0.0"
 
-"@commitlint/is-ignored@^14.0.0":
-  version "14.0.0"
-  resolved "https://registry.yarnpkg.com/@commitlint/is-ignored/-/is-ignored-14.0.0.tgz#8c88e05211519bc187558aad07eee02581292ec4"
-  integrity sha512-nJltYjXTa+mk+6SPe35nOZCCvt3Gh5mbDz008KQ4OPcn1GX1NG+pEgz1Kx3agDp/pc+JGnsrr5GV00gygIoloA==
+"@commitlint/is-ignored@^16.0.0":
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/@commitlint/is-ignored/-/is-ignored-16.0.0.tgz#5ab4c4a9c7444c1a8540f50a0f1a907dfd78eb70"
+  integrity sha512-gmAQcwIGC/R/Lp0CEb2b5bfGC7MT5rPe09N8kOGjO/NcdNmfFSZMquwrvNJsq9hnAP0skRdHIsqwlkENkN4Lag==
   dependencies:
-    "@commitlint/types" "^14.0.0"
+    "@commitlint/types" "^16.0.0"
     semver "7.3.5"
 
-"@commitlint/lint@^14.1.0":
-  version "14.1.0"
-  resolved "https://registry.yarnpkg.com/@commitlint/lint/-/lint-14.1.0.tgz#1673b216803d65cc4bbe631f656125be54fd2f69"
-  integrity sha512-CApGJEOtWU/CcuPD8HkOR1jdUYpjKutGPaeby9nSFzJhwl/UQOjxc4Nd+2g2ygsMi5l3N4j2sWQYEgccpFC3lA==
+"@commitlint/lint@^16.0.0":
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/@commitlint/lint/-/lint-16.0.0.tgz#87151a935941073027907fd4752a2e3c83cebbfe"
+  integrity sha512-HNl15bRC0h+pLzbMzQC3tM0j1aESXsLYhElqKnXcf5mnCBkBkHzu6WwJW8rZbfxX+YwJmNljN62cPhmdBo8x0A==
   dependencies:
-    "@commitlint/is-ignored" "^14.0.0"
-    "@commitlint/parse" "^14.0.0"
-    "@commitlint/rules" "^14.1.0"
-    "@commitlint/types" "^14.0.0"
+    "@commitlint/is-ignored" "^16.0.0"
+    "@commitlint/parse" "^16.0.0"
+    "@commitlint/rules" "^16.0.0"
+    "@commitlint/types" "^16.0.0"
 
-"@commitlint/load@^14.1.0":
-  version "14.1.0"
-  resolved "https://registry.yarnpkg.com/@commitlint/load/-/load-14.1.0.tgz#911e8625cfa1a80df2914b835834c6068fdfdab4"
-  integrity sha512-p+HbgjhkqLsnxyjOUdEYHztHCp8n2oLVUJTmRPuP5FXLNevh6Gwmxf+NYC2J0sgD084aV2CFi3qu1W4yHWIknA==
+"@commitlint/load@^16.1.0":
+  version "16.1.0"
+  resolved "https://registry.yarnpkg.com/@commitlint/load/-/load-16.1.0.tgz#7a884072ab915611080c5e99a1f1d999c05f4360"
+  integrity sha512-MtlEhKjP8jAF85jjX4mw8DUUwCxKsCgAc865hhpnwxjrfBcmGP7Up2AFE/M3ZMGDmSl1X1TMybQk/zohj8Cqdg==
   dependencies:
-    "@commitlint/execute-rule" "^14.0.0"
-    "@commitlint/resolve-extends" "^14.1.0"
-    "@commitlint/types" "^14.0.0"
-    "@endemolshinegroup/cosmiconfig-typescript-loader" "^3.0.2"
+    "@commitlint/config-validator" "^16.1.0"
+    "@commitlint/execute-rule" "^16.0.0"
+    "@commitlint/resolve-extends" "^16.1.0"
+    "@commitlint/types" "^16.0.0"
     chalk "^4.0.0"
     cosmiconfig "^7.0.0"
+    cosmiconfig-typescript-loader "^1.0.0"
     lodash "^4.17.19"
     resolve-from "^5.0.0"
     typescript "^4.4.3"
 
-"@commitlint/message@^14.0.0":
-  version "14.0.0"
-  resolved "https://registry.yarnpkg.com/@commitlint/message/-/message-14.0.0.tgz#4db852fcd76352be547811d57709667588a39ba9"
-  integrity sha512-316Pum+bwDcZamOQw0DXSY17Dq9EjvL1zKdYIZqneu4lnXN6uFfi53Y/sP5crW6zlLdnuTHe1MnuewXPLHfH1Q==
+"@commitlint/message@^16.0.0":
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/@commitlint/message/-/message-16.0.0.tgz#4a467341fc6bc49e5a3ead005dd6aa36fa856b87"
+  integrity sha512-CmK2074SH1Ws6kFMEKOKH/7hMekGVbOD6vb4alCOo2+33ZSLUIX8iNkDYyrw38Jwg6yWUhLjyQLUxREeV+QIUA==
 
-"@commitlint/parse@^14.0.0":
-  version "14.0.0"
-  resolved "https://registry.yarnpkg.com/@commitlint/parse/-/parse-14.0.0.tgz#cb6f66323a27617744f9b479cf09941ff9c3f93d"
-  integrity sha512-49qkk0TcwdxJPZUX8MElEzMlRFIL/cg64P4pk8HotFEm2HYdbxxZp6v3cbVw5WOsnRA0frrs+NNoOcIT83ccMQ==
+"@commitlint/parse@^16.0.0":
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/@commitlint/parse/-/parse-16.0.0.tgz#5ce05af14edff806effc702ba910fcb32fcb192a"
+  integrity sha512-F9EjFlMw4MYgBEqoRrWZZKQBzdiJzPBI0qFDFqwUvfQsMmXEREZ242T4R5bFwLINWaALFLHEIa/FXEPa6QxCag==
   dependencies:
-    "@commitlint/types" "^14.0.0"
+    "@commitlint/types" "^16.0.0"
     conventional-changelog-angular "^5.0.11"
     conventional-commits-parser "^3.2.2"
 
-"@commitlint/read@^14.0.0":
-  version "14.0.0"
-  resolved "https://registry.yarnpkg.com/@commitlint/read/-/read-14.0.0.tgz#f871600ce815b541c7f1a4fdabe2c66d8840c2ab"
-  integrity sha512-WXXcSLBqwXTqnEmB0lbU2TrayDJ2G3qI/lxy1ianVmpQol8p9BjodAA6bYxtYYHdQFVXUrIsclzFP/naWG+hlQ==
+"@commitlint/read@^16.0.0":
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/@commitlint/read/-/read-16.0.0.tgz#92fab45d4e0e4d7d049427306500270b3e459221"
+  integrity sha512-H4T2zsfmYQK9B+JtoQaCXWBHUhgIJyOzWZjSfuIV9Ce69/OgHoffNpLZPF2lX6yKuDrS1SQFhI/kUCjVc/e4ew==
   dependencies:
-    "@commitlint/top-level" "^14.0.0"
-    "@commitlint/types" "^14.0.0"
+    "@commitlint/top-level" "^16.0.0"
+    "@commitlint/types" "^16.0.0"
     fs-extra "^10.0.0"
     git-raw-commits "^2.0.0"
 
-"@commitlint/resolve-extends@^14.1.0":
-  version "14.1.0"
-  resolved "https://registry.yarnpkg.com/@commitlint/resolve-extends/-/resolve-extends-14.1.0.tgz#f23b40d95c95901fcb7b53edebc8fe86f54fe99d"
-  integrity sha512-ko80k6QB6E6/OvGNWy4u7gzzWyluDT3VDNL2kfZaDywsnrYntUKyT4Do97gQ7orttITzj2GRtk3KWClVz4rUUQ==
+"@commitlint/resolve-extends@^16.1.0":
+  version "16.1.0"
+  resolved "https://registry.yarnpkg.com/@commitlint/resolve-extends/-/resolve-extends-16.1.0.tgz#4b199197c45ddb436b59ef319662de6870f68fd5"
+  integrity sha512-8182s6AFoUFX6+FT1PgQDt15nO2ogdR/EN8SYVAdhNXw1rLz8kT5saB/ICw567GuRAUgFTUMGCXy3ctMOXPEDg==
   dependencies:
+    "@commitlint/config-validator" "^16.1.0"
+    "@commitlint/types" "^16.0.0"
     import-fresh "^3.0.0"
     lodash "^4.17.19"
     resolve-from "^5.0.0"
     resolve-global "^1.0.0"
 
-"@commitlint/rules@^14.1.0":
-  version "14.1.0"
-  resolved "https://registry.yarnpkg.com/@commitlint/rules/-/rules-14.1.0.tgz#caec339b05c45e7536cac5d9f1db11fcc9e3dfcd"
-  integrity sha512-6jmv414/1JzGzDI/DS+snAMhcL6roQKPdg0WB3kWTWN52EvWXBFm0HIMGt2H/FlRKxozwVXlQN60/1fNIl98xA==
+"@commitlint/rules@^16.0.0":
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/@commitlint/rules/-/rules-16.0.0.tgz#79d28c3678d2d1f7f1cdbedaedb30b01a86ee75b"
+  integrity sha512-AOl0y2SBTdJ1bvIv8nwHvQKRT/jC1xb09C5VZwzHoT8sE8F54KDeEzPCwHQFgUcWdGLyS10kkOTAH2MyA8EIlg==
   dependencies:
-    "@commitlint/ensure" "^14.1.0"
-    "@commitlint/message" "^14.0.0"
-    "@commitlint/to-lines" "^14.0.0"
-    "@commitlint/types" "^14.0.0"
+    "@commitlint/ensure" "^16.0.0"
+    "@commitlint/message" "^16.0.0"
+    "@commitlint/to-lines" "^16.0.0"
+    "@commitlint/types" "^16.0.0"
     execa "^5.0.0"
 
-"@commitlint/to-lines@^14.0.0":
-  version "14.0.0"
-  resolved "https://registry.yarnpkg.com/@commitlint/to-lines/-/to-lines-14.0.0.tgz#d90c7453bc678e7e2d8a4cae125783b1d4df7aa4"
-  integrity sha512-uIXk54oJDuYyLpI208s3+cGmJ323yvSJ9LB7yUDMWUeJi2LgRxE2EBZL995kLQdnoAsBBXcLq+VDyppg5bV/cg==
+"@commitlint/to-lines@^16.0.0":
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/@commitlint/to-lines/-/to-lines-16.0.0.tgz#799980a89072302445baf595e20092fb86f0a58a"
+  integrity sha512-iN/qU38TCKU7uKOg6RXLpD49wNiuI0TqMqybHbjefUeP/Jmzxa8ishryj0uLyVdrAl1ZjGeD1ukXGMTtvqz8iA==
 
-"@commitlint/top-level@^14.0.0":
-  version "14.0.0"
-  resolved "https://registry.yarnpkg.com/@commitlint/top-level/-/top-level-14.0.0.tgz#5fed6ac7ae2f5cff02ea1f41bddbfa24487ef3c8"
-  integrity sha512-MZDKZfWfl9g4KozgWBGTCrI2cXkMHnBFlhwvEfrAu5G8wd5aL1f2uWEUMnBMjUikmhVj99i1pzge4XFWHQ29wQ==
+"@commitlint/top-level@^16.0.0":
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/@commitlint/top-level/-/top-level-16.0.0.tgz#7c2efc33cc37df839b3de558c0bc2eaddb64efe6"
+  integrity sha512-/Jt6NLxyFkpjL5O0jxurZPCHURZAm7cQCqikgPCwqPAH0TLgwqdHjnYipl8J+AGnAMGDip4FNLoYrtgIpZGBYw==
   dependencies:
     find-up "^5.0.0"
 
-"@commitlint/types@^14.0.0":
-  version "14.0.0"
-  resolved "https://registry.yarnpkg.com/@commitlint/types/-/types-14.0.0.tgz#17bf4d1ab1178c67990ce01b36017d6e6792b751"
-  integrity sha512-sIls1nP2uSbGL466edYlh8mn7O/WP4i3bcvP+2DMhkscRCSgaPhNRWDilhYVsHt2Vu1HTQ27uT0Bj5/Lt2+EcQ==
+"@commitlint/types@^16.0.0":
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/@commitlint/types/-/types-16.0.0.tgz#3c133f106d36132756c464071a7f2290966727a3"
+  integrity sha512-+0FvYOAS39bJ4aKjnYn/7FD4DfWkmQ6G/06I4F0Gvu4KS5twirEg8mIcLhmeRDOOKn4Tp8PwpLwBiSA6npEMQA==
   dependencies:
     chalk "^4.0.0"
 
-"@endemolshinegroup/cosmiconfig-typescript-loader@^3.0.2":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@endemolshinegroup/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-3.0.2.tgz#eea4635828dde372838b0909693ebd9aafeec22d"
-  integrity sha512-QRVtqJuS1mcT56oHpVegkKBlgtWjXw/gHNWO3eL9oyB5Sc7HBoc2OLG/nYpVfT/Jejvo3NUrD0Udk7XgoyDKkA==
+"@cspotcode/source-map-consumer@0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz#33bf4b7b39c178821606f669bbc447a6a629786b"
+  integrity sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==
+
+"@cspotcode/source-map-support@0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz#4789840aa859e46d2f3173727ab707c66bf344f5"
+  integrity sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==
   dependencies:
-    lodash.get "^4"
-    make-error "^1"
-    ts-node "^9"
-    tslib "^2"
+    "@cspotcode/source-map-consumer" "0.8.0"
 
 "@gar/promisify@^1.0.1":
   version "1.1.2"
@@ -1814,6 +1827,26 @@
   resolved "https://registry.yarnpkg.com/@trysound/sax/-/sax-0.2.0.tgz#cccaab758af56761eb7bf37af6f03f326dd798ad"
   integrity sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==
 
+"@tsconfig/node10@^1.0.7":
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.8.tgz#c1e4e80d6f964fbecb3359c43bd48b40f7cadad9"
+  integrity sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==
+
+"@tsconfig/node12@^1.0.7":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.9.tgz#62c1f6dee2ebd9aead80dc3afa56810e58e1a04c"
+  integrity sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==
+
+"@tsconfig/node14@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.1.tgz#95f2d167ffb9b8d2068b0b235302fafd4df711f2"
+  integrity sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==
+
+"@tsconfig/node16@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.2.tgz#423c77877d0569db20e1fc80885ac4118314010e"
+  integrity sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==
+
 "@types/aria-query@^4.2.0":
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-4.2.2.tgz#ed4e0ad92306a704f9fb132a0cfcf77486dbe2bc"
@@ -2000,6 +2033,11 @@ acorn-walk@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.2.0.tgz#0de889a601203909b0fbe07b8938dc21d2e967bc"
   integrity sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==
 
+acorn-walk@^8.1.1:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
+  integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
+
 acorn@^7.1.1:
   version "7.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
@@ -2009,6 +2047,11 @@ acorn@^8.2.4:
   version "8.5.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.5.0.tgz#4512ccb99b3698c752591e9bb4472e38ad43cee2"
   integrity sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==
+
+acorn@^8.4.1:
+  version "8.7.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.7.0.tgz#90951fde0f8f09df93549481e5fc141445b791cf"
+  integrity sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==
 
 agent-base@6, agent-base@^6.0.2:
   version "6.0.2"
@@ -2034,7 +2077,7 @@ aggregate-error@^3.0.0:
     clean-stack "^2.0.0"
     indent-string "^4.0.0"
 
-ajv@^6.12.3:
+ajv@^6.12.3, ajv@^6.12.6:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
   integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
@@ -2866,7 +2909,15 @@ core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
   integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
 
-cosmiconfig@^7.0.0:
+cosmiconfig-typescript-loader@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-1.0.4.tgz#2903d53aec07c8079c5ff4aa1b10bd5d2fbdff81"
+  integrity sha512-ulv2dvwurP/MZAIthXm69bO7EzzIUThZ6RJ1qXhdlXM6to3F+IKBL/17EnhYSG52A5N1KcAUu66vSG/3/77KrA==
+  dependencies:
+    cosmiconfig "^7"
+    ts-node "^10.4.0"
+
+cosmiconfig@^7, cosmiconfig@^7.0.0:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-7.0.1.tgz#714d756522cace867867ccb4474c5d01bbae5d6d"
   integrity sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==
@@ -5089,11 +5140,6 @@ lodash.escaperegexp@^4.1.2:
   resolved "https://registry.yarnpkg.com/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz#64762c48618082518ac3df4ccf5d5886dae20347"
   integrity sha1-ZHYsSGGAglGKw99Mz11YhtriA0c=
 
-lodash.get@^4:
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
-  integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
-
 lodash.ismatch@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz#756cb5150ca3ba6f11085a78849645f188f85f37"
@@ -5163,7 +5209,7 @@ make-dir@^3.0.0:
   dependencies:
     semver "^6.0.0"
 
-make-error@^1, make-error@^1.1.1:
+make-error@^1.1.1:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
@@ -6990,7 +7036,7 @@ source-map-resolve@^0.6.0:
     atob "^2.1.2"
     decode-uri-component "^0.2.0"
 
-source-map-support@^0.5.17, source-map-support@^0.5.6, source-map-support@~0.5.20:
+source-map-support@^0.5.6, source-map-support@~0.5.20:
   version "0.5.20"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.20.tgz#12166089f8f5e5e8c56926b377633392dd2cb6c9"
   integrity sha512-n1lZZ8Ve4ksRqizaBQgxXDgKwttHDhyfQjA6YZZn8+AroHbsIz+JjwxQDxbp+7y5OYCI8t1Yk7etjD9CRd2hIw==
@@ -7453,22 +7499,23 @@ trim-newlines@^3.0.0:
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.1.tgz#260a5d962d8b752425b32f3a7db0dcacd176c144"
   integrity sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==
 
-ts-node@^9:
-  version "9.1.1"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-9.1.1.tgz#51a9a450a3e959401bda5f004a72d54b936d376d"
-  integrity sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==
+ts-node@^10.4.0:
+  version "10.4.0"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.4.0.tgz#680f88945885f4e6cf450e7f0d6223dd404895f7"
+  integrity sha512-g0FlPvvCXSIO1JDF6S232P5jPYqBkRL9qly81ZgAOSU7rwI0stphCgd2kLiCrU9DjQCrJMWEqcNSjQL02s6d8A==
   dependencies:
+    "@cspotcode/source-map-support" "0.7.0"
+    "@tsconfig/node10" "^1.0.7"
+    "@tsconfig/node12" "^1.0.7"
+    "@tsconfig/node14" "^1.0.0"
+    "@tsconfig/node16" "^1.0.2"
+    acorn "^8.4.1"
+    acorn-walk "^8.1.1"
     arg "^4.1.0"
     create-require "^1.1.0"
     diff "^4.0.1"
     make-error "^1.1.1"
-    source-map-support "^0.5.17"
     yn "3.1.1"
-
-tslib@^2:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
-  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
 tunnel-agent@^0.6.0:
   version "0.6.0"


### PR DESCRIPTION
This PR adds a `content` prop that allows to set a text content instead of a DOM element.
It also includes a partial rewrite of the underlying Tooltip class which led to a breaking change as the prop `contentClassName` has been renamed to `containerClassName` to be more accurate.