### PR TITLE
Fix classNames reassignment when content is updated, #15

### DIFF
--- a/src/Tooltip.js
+++ b/src/Tooltip.js
@@ -115,11 +115,11 @@ class Tooltip {
 			this.#createTooltip()
 		}
 
-		if (hasContainerClassNameChanged) {
+		if (hasContainerClassNameChanged || hasContentChanged) {
 			this.#tooltip.classList.add(this.#containerClassName || '__tooltip')
 		}
 
-		if (hasPositionChanged) {
+		if (hasPositionChanged || hasContainerClassNameChanged || hasContentChanged) {
 			this.#tooltip.classList.remove(`__tooltip-${oldPosition}`)
 			this.#tooltip.classList.add(`__tooltip-${this.#position}`)
 		}


### PR DESCRIPTION
This PR fixes an issue with the reassignment of the css classes when the content was updated.