### PR TITLE
Allow to set a template element as tooltip content, #29

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ yarn add @untemps/svelte-use-tooltip
 
 <div use:useTooltip={{
         contentSelector: '.tooltip__content',
-        contentClone: false,
         contentActions: {
             '*': {
                 eventType: 'click',
@@ -114,7 +113,6 @@ yarn add @untemps/svelte-use-tooltip
 |---------------------------|---------|-------------------|-----------------------------------------------------------------------------------------------------------------|
 | `content`                 | string  | null              | Text content to display in the tooltip.                                                                         |
 | `contentSelector`         | string  | null              | Selector of the content to display in the tooltip.                                                              |
-| `contentClone`            | boolean | false             | Flag to clone the content to display in the tooltip. If false, the content is removed from its previous parent. |
 | `contentActions`          | object  | null              | Configuration of the tooltip actions (see [Content Actions](#content-actions)).                                 |
 | `containerClassName`      | string  | '__tooltip'       | Class name to apply to the tooltip container.                                                                   |
 | `position`                | string  | 'top'             | Position of the tooltip. Available values: 'top', 'bottom', 'left', 'right'                                     |
@@ -125,6 +123,18 @@ yarn add @untemps/svelte-use-tooltip
 | `leaveDelay`              | number  | 0                 | Delay before hiding the tooltip in milliseconds.                                                                                |
 | `offset`                  | number  | 10                | Distance between the tooltip and the target in pixels.                                                          |
 | `disabled`                | boolean | false             | Flag to disable the tooltip content.                                                                            |
+
+### Content and Content Selector
+
+The tooltip content can be specified either by the `content` prop or the `contentSelector` prop.
+
+`content` must be a text string that will be displayed as is in the tooltip.
+
+It's useful for most of the use cases of a tooltip however sometimes you need to display some more complex content, with interactive elements or formatted text.  
+
+To do so, you may use the `contentSelector` prop that allows to specify the selector of an element from the DOM.
+
+The best option is to use a [template](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/template) HTML element although you may also use a plain element. In this case, **it will remain in the DOM and will be clones in the tooltip**.
 
 ### Content Actions
 
@@ -141,7 +151,6 @@ One event by element is possible so far as elements are referenced by selector. 
 
 <div use:useTooltip={{
     contentSelector: '#content',
-    contentClone: false,
     contentActions: {
         '#button1': {
             eventType: 'mouseenter',

--- a/dev/src/App.svelte
+++ b/dev/src/App.svelte
@@ -23,8 +23,7 @@
 			use:useTooltip={{
 				position: tooltipPosition,
 				content: tooltipTextContent,
-				contentSelector: !tooltipTextContent?.length ? '.tooltip__content' : null,
-				contentClone: true,
+				contentSelector: !tooltipTextContent?.length ? '#tooltip-template' : null,
 				contentActions: {
 					'*': {
 						eventType: 'click',
@@ -40,20 +39,17 @@
 				enterDelay: tooltipEnterDelay,
 				leaveDelay: tooltipLeaveDelay,
 				offset: tooltipOffset,
-				disabled: isTooltipDisabled
+				disabled: isTooltipDisabled,
 			}}
 			class="target"
 		>
 			Hover me
 		</div>
+		<template id="tooltip-template">
+			<span class="tooltip__content">Hi! I'm a <i>fancy</i> <strong>tooltip</strong>!</span>
+		</template>
 		<form class="settings__form">
 			<h1>Settings</h1>
-			<fieldset>
-				<label>
-					Default Tooltip Content:
-					<span class="tooltip__content">Hi! I'm a <i>fancy</i> <strong>tooltip</strong>!</span>
-				</label>
-			</fieldset>
 			<fieldset>
 				<label>
 					Tooltip Text Content:
@@ -204,36 +200,36 @@
 	}
 
 	:global(.tooltip::after) {
-        content: '';
-        position: absolute;
-        margin-left: -5px;
-        border-width: 5px;
-        border-style: solid;
+		content: '';
+		position: absolute;
+		margin-left: -5px;
+		border-width: 5px;
+		border-style: solid;
 	}
 
-    :global(.tooltip-top::after) {
-        bottom: -10px;
-        left: 50%;
-        border-color: #ee7008 transparent transparent transparent;
-    }
+	:global(.tooltip-top::after) {
+		bottom: -10px;
+		left: 50%;
+		border-color: #ee7008 transparent transparent transparent;
+	}
 
-    :global(.tooltip-bottom::after) {
-        top: -10px;
-        left: 50%;
-        border-color: transparent transparent #ee7008 transparent;
-    }
+	:global(.tooltip-bottom::after) {
+		top: -10px;
+		left: 50%;
+		border-color: transparent transparent #ee7008 transparent;
+	}
 
-    :global(.tooltip-left::after) {
-        top: calc(50% - 5px);
-        right: -10px;
-        border-color: transparent transparent transparent #ee7008;
-    }
+	:global(.tooltip-left::after) {
+		top: calc(50% - 5px);
+		right: -10px;
+		border-color: transparent transparent transparent #ee7008;
+	}
 
-    :global(.tooltip-right::after) {
-        top: calc(50% - 5px);
-        left: -5px;
-        border-color: transparent #ee7008 transparent transparent;
-    }
+	:global(.tooltip-right::after) {
+		top: calc(50% - 5px);
+		left: -5px;
+		border-color: transparent #ee7008 transparent transparent;
+	}
 
 	@keyframes fadeIn {
 		from {

--- a/jest/jest.setup.js
+++ b/jest/jest.setup.js
@@ -1,11 +1,13 @@
+import { fireEvent } from '@testing-library/svelte'
+
 const { toBeInTheDocument, toHaveAttribute, toHaveStyle } = require('@testing-library/jest-dom/matchers')
 import '@testing-library/jest-dom/extend-expect'
 
 expect.extend({ toBeInTheDocument, toHaveAttribute, toHaveStyle })
 
-global._createElement = (id = 'foo', parent, attrs) => {
-	const el = document.createElement('div')
-	el.setAttribute('id', id)
+global._createAndAddElement = (tagName, attrs, parent) => {
+	const el = document.createElement(tagName)
+	el.setAttribute('id', 'foo')
 	for (let key in attrs) {
 		el.setAttribute(key, attrs[key])
 	}
@@ -13,7 +15,7 @@ global._createElement = (id = 'foo', parent, attrs) => {
 	return el
 }
 
-global._removeElement = (selector) => {
+global._destroyElement = (selector) => {
 	const el = document.querySelector(selector)
 	if (!!el) {
 		el.parentNode.removeChild(el)
@@ -27,6 +29,60 @@ global._modifyElement = (selector, attributeName, attributeValue) => {
 	}
 }
 
+global._getElement = (selector) => {
+	return document.querySelector(selector)
+}
+
 global._sleep = (ms = 100) => {
 	return new Promise((resolve) => setTimeout(resolve, ms))
 }
+
+global._enter = async (trigger) =>
+	new Promise(async (resolve) => {
+		await fireEvent.mouseOver(trigger) // fireEvent.mouseEnter only works if mouseOver is triggered before
+		await fireEvent.mouseEnter(trigger)
+		await _sleep(1)
+		resolve()
+	})
+
+global._leave = async (trigger) =>
+	new Promise(async (resolve) => {
+		await fireEvent.mouseLeave(trigger)
+		await _sleep(1)
+		resolve()
+	})
+
+global._enterAndLeave = async (trigger) =>
+	new Promise(async (resolve) => {
+		await _enter(trigger)
+		await _leave(trigger)
+		resolve()
+	})
+
+global._focus = async (trigger) =>
+	new Promise(async (resolve) => {
+		await fireEvent.focusIn(trigger)
+		await _sleep(1)
+		resolve()
+	})
+
+global._blur = async (trigger) =>
+	new Promise(async (resolve) => {
+		await fireEvent.focusOut(trigger)
+		await _sleep(1)
+		resolve()
+	})
+
+global._focusAndBlur = async (trigger) =>
+	new Promise(async (resolve) => {
+		await _focus(trigger)
+		await _blur(trigger)
+		resolve()
+	})
+
+global._keyDown = async (trigger, key) =>
+	new Promise(async (resolve) => {
+		await fireEvent.keyDown(trigger, key || { key: 'Escape', code: 'Escape', charCode: 27 })
+		await _sleep(1)
+		resolve()
+	})

--- a/src/Tooltip.js
+++ b/src/Tooltip.js
@@ -13,7 +13,7 @@ class Tooltip {
 
 	#boundEnterHandler = null
 	#boundLeaveHandler = null
-	#boundKeyDownHandler = null
+	#boundWindowChangeHandler = null
 
 	#target = null
 	#content = null
@@ -69,7 +69,7 @@ class Tooltip {
 		this.#target.setAttribute('style', 'position: relative')
 		this.#target.setAttribute('aria-describedby', 'tooltip')
 
-		disabled ? this.#disableTarget() : this.#enableTarget()
+		disabled ? this.#disable() : this.#enable()
 
 		Tooltip.#instances.push(this)
 	}
@@ -117,14 +117,14 @@ class Tooltip {
 		}
 
 		if (hasToDisableTarget) {
-			this.#disableTarget()
+			this.#disable()
 		} else if (hasToEnableTarget) {
-			this.#enableTarget()
+			this.#enable()
 		}
 	}
 
-	destroy() {
-		this.#removeTooltipFromTarget()
+	async destroy() {
+		await this.#removeTooltipFromTarget()
 
 		this.#disableTarget()
 
@@ -134,16 +134,32 @@ class Tooltip {
 		this.#observer = null
 	}
 
+	#enable() {
+		this.#enableTarget()
+		this.#enableWindow()
+	}
+
 	#enableTarget() {
 		this.#boundEnterHandler = this.#onTargetEnter.bind(this)
 		this.#boundLeaveHandler = this.#onTargetLeave.bind(this)
-		this.#boundKeyDownHandler = this.#onTargetKeyDown.bind(this)
 
 		this.#target.addEventListener('mouseenter', this.#boundEnterHandler)
 		this.#target.addEventListener('mouseleave', this.#boundLeaveHandler)
 		this.#target.addEventListener('focusin', this.#boundEnterHandler)
 		this.#target.addEventListener('focusout', this.#boundLeaveHandler)
-		window.addEventListener('keydown', this.#boundKeyDownHandler)
+	}
+
+	#enableWindow() {
+		this.#boundWindowChangeHandler = this.#onWindowChange.bind(this)
+
+		window.addEventListener('keydown', this.#boundWindowChangeHandler)
+		window.addEventListener('resize', this.#boundWindowChangeHandler)
+		window.addEventListener('scroll', this.#boundWindowChangeHandler)
+	}
+
+	#disable() {
+		this.#disableTarget()
+		this.#disableWindow()
 	}
 
 	#disableTarget() {
@@ -151,11 +167,17 @@ class Tooltip {
 		this.#target.removeEventListener('mouseleave', this.#boundLeaveHandler)
 		this.#target.removeEventListener('focusin', this.#boundEnterHandler)
 		this.#target.removeEventListener('focusout', this.#boundLeaveHandler)
-		window.removeEventListener('keydown', this.#boundKeyDownHandler)
 
 		this.#boundEnterHandler = null
 		this.#boundLeaveHandler = null
-		this.#boundKeyDownHandler = null
+	}
+
+	#disableWindow() {
+		window.removeEventListener('keydown', this.#boundWindowChangeHandler)
+		window.removeEventListener('resize', this.#boundWindowChangeHandler)
+		window.removeEventListener('scroll', this.#boundWindowChangeHandler)
+
+		this.#boundWindowChangeHandler = null
 	}
 
 	#createTooltip() {
@@ -340,9 +362,16 @@ class Tooltip {
 		await this.#removeTooltipFromTarget()
 	}
 
-	async #onTargetKeyDown(e) {
-		if (e.key === 'Escape' || e.key === 'Esc' || e.keyCode === 27) {
-			await this.#onTargetLeave()
+	async #onWindowChange(e) {
+		if (
+			this.#tooltip &&
+			this.#tooltip.parentNode &&
+			(e.type !== 'keydown' ||
+				(e.type === 'keydown' && e.key === 'Escape') ||
+				e.key === 'Esc' ||
+				e.keyCode === 27)
+		) {
+			await this.#removeTooltipFromTarget()
 		}
 	}
 }

--- a/src/useTooltip.js
+++ b/src/useTooltip.js
@@ -7,7 +7,6 @@ const useTooltip = (
 	{
 		content,
 		contentSelector,
-		contentClone,
 		contentActions,
 		containerClassName,
 		position,
@@ -24,7 +23,6 @@ const useTooltip = (
 		node,
 		content,
 		contentSelector,
-		contentClone,
 		contentActions,
 		containerClassName,
 		position,
@@ -41,7 +39,6 @@ const useTooltip = (
 		update: ({
 			content: newContent,
 			contentSelector: newContentSelector,
-			contentClone: newContentClone,
 			contentActions: newContentActions,
 			containerClassName: newContainerClassName,
 			position: newPosition,
@@ -56,7 +53,6 @@ const useTooltip = (
 			tooltip.update(
 				newContent,
 				newContentSelector,
-				newContentClone,
 				newContentActions,
 				newContainerClassName,
 				newPosition,


### PR DESCRIPTION
This PR allows to use a template HTML element as tooltip content and remove the `contentClone` prop.