### PR TITLE
Remove tooltip max-width, #34

### DIFF
--- a/src/useTooltip.css
+++ b/src/useTooltip.css
@@ -1,7 +1,6 @@
 .__tooltip {
 	position: absolute;
 	z-index: 9999;
-	max-width: 100%;
 	background-color: black;
 	color: white;
 	text-align: center;


### PR DESCRIPTION
This PR removes tooltip max-width to display tooltip content properly with size-limited targets.

Closes #34 