### PR TITLE
Fix tooltip focus management, #40

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,5 @@
-dist/
+.husky/
+.idea/
+build/
+coverage/
 node_modules/

--- a/.prettierrc
+++ b/.prettierrc
@@ -14,6 +14,17 @@
 				"parser": "babylon"
 			}
 		},
+      {
+        "files": "./**/*.svelte",
+        "options": {
+          "svelteBracketNewLine": false,
+          "svelteAllowShorthand": false,
+          "svelteSortOrder" : "options-scripts-styles-markup",
+          "plugins": [
+            "prettier-plugin-svelte"
+          ]
+        }
+      },
 		{
 			"files": "./**/*.json",
 			"options": {


### PR DESCRIPTION
This PR fixes an issue with the management of the focus : when the tooltip contained interactive elements, triggering events on them might be consider as target focus-out. As there is a callback attached to it, it was called and closed the tooltip.
We now check whether the event target is not an element within the tooltip before executing the content of the focus-out callback.

Closes #40 