### PR TITLE
fix(tooltip): Prune destroyed instances from static #instances array

### DIFF
--- a/src/lib/Tooltip.ts
+++ b/src/lib/Tooltip.ts
@@ -271,6 +271,8 @@ class Tooltip {
 
 		this.#observer?.clear();
 		this.#observer = null;
+
+		Tooltip.#instances = Tooltip.#instances.filter((i) => i !== this);
 	}
 
 	#enable() {

--- a/src/lib/__tests__/useTooltip.test.ts
+++ b/src/lib/__tests__/useTooltip.test.ts
@@ -145,6 +145,25 @@ describe('useTooltip', () => {
 			expect(target).not.toHaveAttribute('title');
 		});
 
+		test('Removes instance from static registry on individual destroy', async () => {
+			const target2 = initTarget('target2');
+			const action2 = createAction(target2, { content: 'tooltip2' });
+			action = createAction(target, options);
+
+			// Destroy action2 individually — it should be pruned from #instances
+			await action2.destroy();
+
+			// Tooltip.destroy() should cleanly destroy remaining instances (only action)
+			// without double-destroying action2 — verified by absence of errors and
+			// correct cleanup of action's target
+			Tooltip.destroy();
+
+			expect(target).not.toHaveAttribute('aria-describedby');
+			expect(target2).not.toHaveAttribute('aria-describedby');
+
+			removeElement('#target2');
+		});
+
 		test('Does not apply update after destroy', async () => {
 			action = createAction(target, options);
 			await action.destroy();


### PR DESCRIPTION
## Summary
Individual calls to `destroy()` did not remove the instance from `Tooltip.#instances`, causing destroyed instances to linger in the static registry and preventing garbage collection of their referenced DOM nodes (`#target`, `#tooltip`, `#observer`, etc.). A `filter` call at the end of `destroy()` removes the instance immediately.

Note: the issue description references a `Map<HTMLElement, Tooltip>` — the actual implementation uses a `Tooltip[]` array. A `WeakMap` is not applicable here because `Tooltip.destroy()` (static) requires iteration over all live instances.

## Changes
- `src/lib/Tooltip.ts` — add `Tooltip.#instances = Tooltip.#instances.filter(i => i !== this)` at the end of `destroy()`
- `src/lib/__tests__/useTooltip.test.ts` — new test: destroy one of two instances individually, then call `Tooltip.destroy()` — both targets are cleaned up, no double-destroy errors

## Test plan
- [ ] Create two tooltip actions, destroy one individually, call `Tooltip.destroy()` — verify both targets lose `aria-describedby` and no error is thrown
- [ ] Verify that `Tooltip.destroy()` still correctly cleans up instances that were never individually destroyed

Closes #129