### PR TITLE
refactor(tooltip): Replace positional parameters with options object

### DIFF
--- a/src/lib/Tooltip.ts
+++ b/src/lib/Tooltip.ts
@@ -12,6 +12,24 @@ export type ContentAction = {
 
 export type ContentActions = Record<string, ContentAction>;
 
+export type TooltipOptions = {
+	content?: string | null;
+	contentSelector?: string | null;
+	contentActions?: ContentActions | null;
+	containerClassName?: string | null;
+	position?: TooltipPosition;
+	animated?: boolean;
+	animationEnterClassName?: string | null;
+	animationLeaveClassName?: string | null;
+	enterDelay?: number;
+	leaveDelay?: number;
+	onEnter?: (() => void) | null;
+	onLeave?: (() => void) | null;
+	offset?: number;
+	width?: string;
+	disabled?: boolean;
+};
+
 type SpaceMap = Record<TooltipPosition, number>;
 type PlacementResult = { position: TooltipPosition; adaptedWidth: string | null };
 type EventRecord = { trigger: Element; eventType: string; listener: EventListener };
@@ -68,24 +86,25 @@ class Tooltip {
 		Tooltip.#instances = [];
 	}
 
-	constructor(
-		target: HTMLElement,
-		content: string | null | undefined,
-		contentSelector: string | null | undefined,
-		contentActions: ContentActions | null | undefined,
-		containerClassName: string | null | undefined,
-		position: TooltipPosition | undefined,
-		animated: boolean | undefined,
-		animationEnterClassName: string | null | undefined,
-		animationLeaveClassName: string | null | undefined,
-		enterDelay: number | undefined,
-		leaveDelay: number | undefined,
-		onEnter: (() => void) | null | undefined,
-		onLeave: (() => void) | null | undefined,
-		offset: number | undefined,
-		width: string | undefined,
-		disabled: boolean | undefined
-	) {
+	constructor(target: HTMLElement, options: TooltipOptions = {}) {
+		const {
+			content,
+			contentSelector,
+			contentActions,
+			containerClassName,
+			position,
+			animated,
+			animationEnterClassName,
+			animationLeaveClassName,
+			enterDelay,
+			leaveDelay,
+			onEnter,
+			onLeave,
+			offset,
+			width,
+			disabled
+		} = options;
+
 		this.#target = target;
 		this.#content = content ?? null;
 		this.#contentSelector = contentSelector ?? null;
@@ -116,24 +135,26 @@ class Tooltip {
 		Tooltip.#instances.push(this);
 	}
 
-	update(
-		content: string | null | undefined,
-		contentSelector: string | null | undefined,
-		contentActions: ContentActions | null | undefined,
-		containerClassName: string | null | undefined,
-		position: TooltipPosition | undefined,
-		animated: boolean | undefined,
-		animationEnterClassName: string | null | undefined,
-		animationLeaveClassName: string | null | undefined,
-		enterDelay: number | undefined,
-		leaveDelay: number | undefined,
-		onEnter: (() => void) | null | undefined,
-		onLeave: (() => void) | null | undefined,
-		offset: number | undefined,
-		width: string | undefined,
-		disabled: boolean | undefined
-	) {
+	update(options: TooltipOptions) {
 		if (this.#destroyed) return;
+
+		const {
+			content,
+			contentSelector,
+			contentActions,
+			containerClassName,
+			position,
+			animated,
+			animationEnterClassName,
+			animationLeaveClassName,
+			enterDelay,
+			leaveDelay,
+			onEnter,
+			onLeave,
+			offset,
+			width,
+			disabled
+		} = options;
 
 		const changes = this.#detectChanges(
 			content,

--- a/src/lib/useTooltip.ts
+++ b/src/lib/useTooltip.ts
@@ -1,102 +1,17 @@
 import type { Action } from 'svelte/action';
 
 import Tooltip from './Tooltip';
-import type { ContentActions, TooltipPosition } from './Tooltip';
+import type { TooltipOptions } from './Tooltip';
 
 import './useTooltip.css';
 
-export interface TooltipOptions {
-	content?: string | null;
-	contentSelector?: string | null;
-	contentActions?: ContentActions | null;
-	containerClassName?: string | null;
-	position?: TooltipPosition;
-	animated?: boolean;
-	animationEnterClassName?: string | null;
-	animationLeaveClassName?: string | null;
-	enterDelay?: number;
-	leaveDelay?: number;
-	onEnter?: (() => void) | null;
-	onLeave?: (() => void) | null;
-	offset?: number;
-	width?: string;
-	disabled?: boolean;
-}
+export type { TooltipOptions };
 
-const useTooltip: Action<HTMLElement, TooltipOptions> = (
-	node,
-	{
-		content,
-		contentSelector,
-		contentActions,
-		containerClassName,
-		position,
-		animated,
-		animationEnterClassName,
-		animationLeaveClassName,
-		enterDelay,
-		leaveDelay,
-		onEnter,
-		onLeave,
-		offset,
-		width,
-		disabled
-	} = {}
-) => {
-	const tooltip = new Tooltip(
-		node,
-		content,
-		contentSelector,
-		contentActions,
-		containerClassName,
-		position,
-		animated,
-		animationEnterClassName,
-		animationLeaveClassName,
-		enterDelay,
-		leaveDelay,
-		onEnter,
-		onLeave,
-		offset,
-		width,
-		disabled
-	);
+const useTooltip: Action<HTMLElement, TooltipOptions> = (node, options = {}) => {
+	const tooltip = new Tooltip(node, options);
 
 	return {
-		update: ({
-			content: newContent,
-			contentSelector: newContentSelector,
-			contentActions: newContentActions,
-			containerClassName: newContainerClassName,
-			position: newPosition,
-			animated: newAnimated,
-			animationEnterClassName: newAnimationEnterClassName,
-			animationLeaveClassName: newAnimationLeaveClassName,
-			enterDelay: newEnterDelay,
-			leaveDelay: newLeaveDelay,
-			onEnter: newOnEnter,
-			onLeave: newOnLeave,
-			offset: newOffset,
-			width: newWidth,
-			disabled: newDisabled
-		}: TooltipOptions) =>
-			tooltip.update(
-				newContent,
-				newContentSelector,
-				newContentActions,
-				newContainerClassName,
-				newPosition,
-				newAnimated,
-				newAnimationEnterClassName,
-				newAnimationLeaveClassName,
-				newEnterDelay,
-				newLeaveDelay,
-				newOnEnter,
-				newOnLeave,
-				newOffset,
-				newWidth,
-				newDisabled
-			),
+		update: (newOptions: TooltipOptions) => tooltip.update(newOptions),
 		destroy: () => tooltip.destroy()
 	};
 };


### PR DESCRIPTION
## Summary
Replace the 15 positional parameters in `Tooltip` constructor and `update()` with a single `TooltipOptions` object. `TooltipOptions` is now defined in `Tooltip.ts` and re-exported from `useTooltip.ts` for backward compatibility. `useTooltip.ts` is simplified to pass options directly instead of spreading them into individual arguments.

## Changes
- `src/lib/Tooltip.ts` — add `TooltipOptions` export; update constructor to `(target, options = {})`; update `update()` to `(options)`; both destructure internally before delegating to private methods
- `src/lib/useTooltip.ts` — remove local `TooltipOptions` definition, import from `Tooltip.ts`, re-export it; simplify to `new Tooltip(node, options)` and `tooltip.update(newOptions)`

## Test plan
- [ ] All 192 existing tests pass without modification — the public `useTooltip` API is unchanged
- [ ] Build produces no type errors

Closes #130