### PR TITLE
refactor(tooltip): Pass TooltipOptions directly to private methods

### DIFF
--- a/src/lib/Tooltip.ts
+++ b/src/lib/Tooltip.ts
@@ -137,62 +137,20 @@ class Tooltip {
 
 	update(options: TooltipOptions) {
 		if (this.#destroyed) return;
-
-		const {
-			content,
-			contentSelector,
-			contentActions,
-			containerClassName,
-			position,
-			animated,
-			animationEnterClassName,
-			animationLeaveClassName,
-			enterDelay,
-			leaveDelay,
-			onEnter,
-			onLeave,
-			offset,
-			width,
-			disabled
-		} = options;
-
-		const changes = this.#detectChanges(
-			content,
-			contentSelector,
-			containerClassName,
-			position,
-			offset,
-			width,
-			disabled
-		);
-		this.#applyState(
-			content,
-			contentSelector,
-			contentActions,
-			containerClassName,
-			position,
-			animated,
-			animationEnterClassName,
-			animationLeaveClassName,
-			enterDelay,
-			leaveDelay,
-			onEnter,
-			onLeave,
-			offset,
-			width
-		);
+		const changes = this.#detectChanges(options);
+		this.#applyState(options);
 		this.#applyChanges(changes);
 	}
 
-	#detectChanges(
-		content: string | null | undefined,
-		contentSelector: string | null | undefined,
-		containerClassName: string | null | undefined,
-		position: TooltipPosition | undefined,
-		offset: number | undefined,
-		width: string | undefined,
-		disabled: boolean | undefined
-	): ChangeSet {
+	#detectChanges({
+		content,
+		contentSelector,
+		containerClassName,
+		position,
+		offset,
+		width,
+		disabled
+	}: TooltipOptions): ChangeSet {
 		const hasContentChanged =
 			(contentSelector !== undefined && contentSelector !== this.#contentSelector) ||
 			(content !== undefined && content !== this.#content);
@@ -210,22 +168,22 @@ class Tooltip {
 		};
 	}
 
-	#applyState(
-		content: string | null | undefined,
-		contentSelector: string | null | undefined,
-		contentActions: ContentActions | null | undefined,
-		containerClassName: string | null | undefined,
-		position: TooltipPosition | undefined,
-		animated: boolean | undefined,
-		animationEnterClassName: string | null | undefined,
-		animationLeaveClassName: string | null | undefined,
-		enterDelay: number | undefined,
-		leaveDelay: number | undefined,
-		onEnter: (() => void) | null | undefined,
-		onLeave: (() => void) | null | undefined,
-		offset: number | undefined,
-		width: string | undefined
-	) {
+	#applyState({
+		content,
+		contentSelector,
+		contentActions,
+		containerClassName,
+		position,
+		animated,
+		animationEnterClassName,
+		animationLeaveClassName,
+		enterDelay,
+		leaveDelay,
+		onEnter,
+		onLeave,
+		offset,
+		width
+	}: TooltipOptions) {
 		this.#content = content ?? null;
 		this.#contentSelector = contentSelector ?? null;
 		this.#contentActions = contentActions ?? null;


### PR DESCRIPTION
## Summary
Following PR #160 which introduced `TooltipOptions` for the public interface, `update()` was still destructuring the object only to immediately re-spread individual values into `#detectChanges` and `#applyState` as positional arguments. This PR completes the refactor by passing `TooltipOptions` directly to both private methods, reducing `update()` to three lines.

## Changes
- `src/lib/Tooltip.ts` — `#detectChanges` and `#applyState` now destructure `TooltipOptions` in their parameter lists; `update()` passes `options` directly with no local destructuring (-42 lines net)

## Test plan
- [ ] All 192 existing tests pass without modification
- [ ] Build produces no type errors

Closes #161