### PR TITLE
fix(a11y): Generate unique IDs for aria-describedby to avoid ARIA collisions

### DIFF
--- a/src/lib/Tooltip.ts
+++ b/src/lib/Tooltip.ts
@@ -69,6 +69,8 @@ class Tooltip {
 	#offset = 10;
 	#width = 'auto';
 
+	#id: string;
+
 	#originalTitle: string | null = null;
 
 	#open: boolean | undefined = undefined;
@@ -127,6 +129,8 @@ class Tooltip {
 		this.#offset = Math.max(offset ?? 10, 5);
 		this.#width = width ?? 'auto';
 
+		this.#id = `tooltip-${crypto.randomUUID()}`;
+
 		this.#observer = new DOMObserver();
 
 		this.#createTooltip();
@@ -134,7 +138,6 @@ class Tooltip {
 		this.#originalTitle = this.#target.getAttribute('title');
 		this.#target.removeAttribute('title');
 		this.#target.style.position = 'relative';
-		this.#target.setAttribute('aria-describedby', 'tooltip');
 
 		this.#open = open === true ? true : undefined;
 
@@ -338,7 +341,7 @@ class Tooltip {
 
 	#createTooltip() {
 		this.#tooltip = document.createElement('div');
-		this.#tooltip.setAttribute('id', 'tooltip');
+		this.#tooltip.setAttribute('id', this.#id);
 		this.#tooltip.setAttribute(
 			'class',
 			this.#containerClassName || `__tooltip __tooltip-${this.#position}`
@@ -510,6 +513,8 @@ class Tooltip {
 			await this.#transitionTooltip(true);
 		}
 
+		this.#target!.setAttribute('aria-describedby', this.#id);
+
 		this.#observer!.wait(this.#tooltip!, { events: [DOMObserver.ADD] }).then(() => {
 			if (this.#destroyed) return;
 			this.#positionTooltip();
@@ -543,6 +548,7 @@ class Tooltip {
 		}
 
 		this.#tooltip!.remove();
+		this.#target?.removeAttribute('aria-describedby');
 
 		if (!this.#containerClassName) {
 			this.#tooltip!.setAttribute('class', `__tooltip __tooltip-${this.#position}`);

--- a/src/lib/__tests__/useTooltip.test.ts
+++ b/src/lib/__tests__/useTooltip.test.ts
@@ -98,7 +98,7 @@ describe('useTooltip', () => {
 		});
 
 		test('Preserves existing inline styles on template child after cloning', async () => {
-			const template = document.querySelector('#template') as HTMLTemplateElement;
+			const template = getElement('#template') as HTMLTemplateElement;
 			const child = template.content.firstElementChild as HTMLElement;
 			child.style.fontSize = '14px';
 
@@ -939,32 +939,32 @@ describe('useTooltip', () => {
 		test('Shows tooltip programmatically on init when open is true', async () => {
 			action = createAction(target, { content: 'Hello', open: true });
 			await standby(1);
-			expect(getElement('#tooltip')).toBeInTheDocument();
+			expect(getElement('[role=\"tooltip\"]')).toBeInTheDocument();
 		});
 
 		test('Does not show tooltip on init when open is false', async () => {
 			action = createAction(target, { content: 'Hello', open: false });
 			await standby(1);
-			expect(getElement('#tooltip')).not.toBeInTheDocument();
+			expect(getElement('[role=\"tooltip\"]')).not.toBeInTheDocument();
 		});
 
 		test('Shows tooltip programmatically via update', async () => {
 			action = createAction(target, { content: 'Hello' });
-			expect(getElement('#tooltip')).not.toBeInTheDocument();
+			expect(getElement('[role=\"tooltip\"]')).not.toBeInTheDocument();
 
 			action.update({ content: 'Hello', open: true });
 			await standby(1);
-			expect(getElement('#tooltip')).toBeInTheDocument();
+			expect(getElement('[role=\"tooltip\"]')).toBeInTheDocument();
 		});
 
 		test('Hides tooltip programmatically via update', async () => {
 			action = createAction(target, { content: 'Hello', open: true });
 			await standby(1);
-			expect(getElement('#tooltip')).toBeInTheDocument();
+			expect(getElement('[role=\"tooltip\"]')).toBeInTheDocument();
 
 			action.update({ content: 'Hello', open: false });
 			await standby(1);
-			expect(getElement('#tooltip')).not.toBeInTheDocument();
+			expect(getElement('[role=\"tooltip\"]')).not.toBeInTheDocument();
 		});
 
 		test('Toggles tooltip via successive open updates', async () => {
@@ -972,34 +972,34 @@ describe('useTooltip', () => {
 
 			action.update({ content: 'Hello', open: true });
 			await standby(1);
-			expect(getElement('#tooltip')).toBeInTheDocument();
+			expect(getElement('[role=\"tooltip\"]')).toBeInTheDocument();
 
 			action.update({ content: 'Hello', open: false });
 			await standby(1);
-			expect(getElement('#tooltip')).not.toBeInTheDocument();
+			expect(getElement('[role=\"tooltip\"]')).not.toBeInTheDocument();
 
 			action.update({ content: 'Hello', open: true });
 			await standby(1);
-			expect(getElement('#tooltip')).toBeInTheDocument();
+			expect(getElement('[role=\"tooltip\"]')).toBeInTheDocument();
 		});
 
 		test('Is a no-op when open is false and tooltip is already hidden', async () => {
 			action = createAction(target, { content: 'Hello' });
-			expect(getElement('#tooltip')).not.toBeInTheDocument();
+			expect(getElement('[role=\"tooltip\"]')).not.toBeInTheDocument();
 
 			action.update({ content: 'Hello', open: false });
 			await standby(1);
-			expect(getElement('#tooltip')).not.toBeInTheDocument();
+			expect(getElement('[role=\"tooltip\"]')).not.toBeInTheDocument();
 		});
 
 		test('Is a no-op when open is true and tooltip is already shown', async () => {
 			action = createAction(target, { content: 'Hello', open: true });
 			await standby(1);
-			expect(getElement('#tooltip')).toBeInTheDocument();
+			expect(getElement('[role=\"tooltip\"]')).toBeInTheDocument();
 
 			action.update({ content: 'Hello', open: true });
 			await standby(1);
-			expect(getElement('#tooltip')).toBeInTheDocument();
+			expect(getElement('[role=\"tooltip\"]')).toBeInTheDocument();
 		});
 
 		test('Preserves normal hover behavior alongside open prop', async () => {
@@ -1007,84 +1007,143 @@ describe('useTooltip', () => {
 
 			// open via hover
 			await _enter(target);
-			expect(getElement('#tooltip')).toBeInTheDocument();
+			expect(getElement('[role=\"tooltip\"]')).toBeInTheDocument();
 
 			// close programmatically
 			action.update({ content: 'Hello', open: false });
 			await standby(1);
-			expect(getElement('#tooltip')).not.toBeInTheDocument();
+			expect(getElement('[role=\"tooltip\"]')).not.toBeInTheDocument();
 
 			// open programmatically
 			action.update({ content: 'Hello', open: true });
 			await standby(1);
-			expect(getElement('#tooltip')).toBeInTheDocument();
+			expect(getElement('[role=\"tooltip\"]')).toBeInTheDocument();
 
 			// release open lock — hover-away should close again
 			action.update({ content: 'Hello' });
 			await _leave(target);
-			expect(getElement('#tooltip')).not.toBeInTheDocument();
+			expect(getElement('[role=\"tooltip\"]')).not.toBeInTheDocument();
 		});
 
 		test('Does not show tooltip on init when open is true and disabled is true', async () => {
 			action = createAction(target, { content: 'Hello', open: true, disabled: true });
 			await standby(1);
-			expect(getElement('#tooltip')).not.toBeInTheDocument();
+			expect(getElement('[role=\"tooltip\"]')).not.toBeInTheDocument();
 		});
 
 		test('Does not show tooltip via update when open is true and disabled is true', async () => {
 			action = createAction(target, { content: 'Hello' });
 			action.update({ content: 'Hello', open: true, disabled: true });
 			await standby(1);
-			expect(getElement('#tooltip')).not.toBeInTheDocument();
+			expect(getElement('[role=\"tooltip\"]')).not.toBeInTheDocument();
 		});
 
 		test('Restores hover after open: false (one-shot close, no lock)', async () => {
 			action = createAction(target, { content: 'Hello', open: true });
 			await standby(1);
-			expect(getElement('#tooltip')).toBeInTheDocument();
+			expect(getElement('[role=\"tooltip\"]')).toBeInTheDocument();
 
 			action.update({ content: 'Hello', open: false });
 			await standby(1);
-			expect(getElement('#tooltip')).not.toBeInTheDocument();
+			expect(getElement('[role=\"tooltip\"]')).not.toBeInTheDocument();
 
 			// hover must work again — no lock
 			await _enter(target);
-			expect(getElement('#tooltip')).toBeInTheDocument();
+			expect(getElement('[role=\"tooltip\"]')).toBeInTheDocument();
 		});
 
 		test('Keeps tooltip open when open is true and user hovers away', async () => {
 			action = createAction(target, { content: 'Hello', open: true });
 			await standby(1);
-			expect(getElement('#tooltip')).toBeInTheDocument();
+			expect(getElement('[role=\"tooltip\"]')).toBeInTheDocument();
 
 			await _leave(target);
-			expect(getElement('#tooltip')).toBeInTheDocument();
+			expect(getElement('[role=\"tooltip\"]')).toBeInTheDocument();
 		});
 
 		test('Keeps tooltip open when open is true and Escape key is pressed', async () => {
 			action = createAction(target, { content: 'Hello', open: true });
 			await standby(1);
-			expect(getElement('#tooltip')).toBeInTheDocument();
+			expect(getElement('[role=\"tooltip\"]')).toBeInTheDocument();
 
 			await _keyDown(target);
-			expect(getElement('#tooltip')).toBeInTheDocument();
+			expect(getElement('[role=\"tooltip\"]')).toBeInTheDocument();
 		});
 
 		test('Allows hover after open is false (no lock)', async () => {
 			action = createAction(target, { content: 'Hello', open: false });
 			await _enter(target);
-			expect(getElement('#tooltip')).toBeInTheDocument();
+			expect(getElement('[role=\"tooltip\"]')).toBeInTheDocument();
 		});
 
 		test('Re-shows tooltip after content update when open is true', async () => {
 			action = createAction(target, { content: 'Hello', open: true });
 			await standby(1);
-			expect(getElement('#tooltip')).toBeInTheDocument();
+			expect(getElement('[role=\"tooltip\"]')).toBeInTheDocument();
 
 			// structure change + open: true — tooltip must still be visible after rebuild
 			action.update({ content: 'Updated', open: true });
 			await standby(1);
-			expect(getElement('#tooltip')).toBeInTheDocument();
+			expect(getElement('[role=\"tooltip\"]')).toBeInTheDocument();
+		});
+	});
+
+	describe('useTooltip aria-describedby', () => {
+		test('Sets aria-describedby on the target when tooltip is shown', async () => {
+			action = createAction(target, options);
+			await _enter(target);
+			expect(target).toHaveAttribute('aria-describedby');
+		});
+
+		test('aria-describedby value matches the tooltip id', async () => {
+			action = createAction(target, options);
+			await _enter(target);
+			const tooltip = getElement('[role=\"tooltip\"]') as HTMLElement;
+			expect(tooltip.id).toMatch(/^tooltip-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+			expect(target.getAttribute('aria-describedby')).toBe(tooltip.id);
+		});
+
+		test('Removes aria-describedby from target when tooltip is hidden', async () => {
+			action = createAction(target, options);
+			await _enter(target);
+			expect(target).toHaveAttribute('aria-describedby');
+			await _leave(target);
+			expect(target).not.toHaveAttribute('aria-describedby');
+		});
+
+		test('Re-adds aria-describedby when tooltip is shown again', async () => {
+			action = createAction(target, options);
+			await _enter(target);
+			await _leave(target);
+			await _enter(target);
+			expect(target).toHaveAttribute('aria-describedby');
+		});
+
+		test('Two tooltip instances have distinct IDs', async () => {
+			const target2 = createElement({
+				tag: 'div',
+				attributes: { id: 'target2' },
+				parent: document.body
+			});
+			const action2 = useTooltip(target2, { content: 'World' }) as FullAction;
+
+			action = createAction(target, options);
+			await _enter(target);
+			await _enter(target2);
+
+			const id1 = target.getAttribute('aria-describedby');
+			const id2 = target2.getAttribute('aria-describedby');
+			expect(id1).toBeTruthy();
+			expect(id2).toBeTruthy();
+			expect(id1).not.toBe(id2);
+
+			await action2.destroy();
+			removeElement('#target2');
+		});
+
+		test('Does not set aria-describedby before tooltip is shown', () => {
+			action = createAction(target, options);
+			expect(target).not.toHaveAttribute('aria-describedby');
 		});
 	});
 });


### PR DESCRIPTION
## Summary

- Replace the static `id="tooltip"` / `aria-describedby="tooltip"` pattern with a per-instance unique ID (`tooltip-<random>`) generated at construction time
- `aria-describedby` is now set on the target when the tooltip is shown and removed when it is hidden, so it never points to a detached element
- Two tooltip instances on the same page no longer share the same ID, avoiding ARIA collisions

## Changes

- `src/lib/Tooltip.ts` — add `#id` private field, generate unique ID in constructor, set `id` on tooltip container, set/remove `aria-describedby` on show/hide
- `src/lib/__tests__/useTooltip.test.ts` — replace `getElement('#tooltip')` (static ID) with `getElement('[role="tooltip"]')` in the `open` prop suite; add 6 new tests covering the aria-describedby lifecycle and uniqueness guarantee

## Test plan

- [ ] All 255 tests pass (`yarn test:ci`)
- [ ] Two tooltips rendered simultaneously have distinct IDs
- [ ] `aria-describedby` is absent before hover, present while tooltip is visible, removed after leave
- [ ] `aria-describedby` value matches the `id` of the tooltip container

Closes #131