### PR TITLE
feat(a11y): Add aria-expanded to trigger when tooltip has interactive content

### DIFF
--- a/src/lib/Tooltip.ts
+++ b/src/lib/Tooltip.ts
@@ -42,6 +42,7 @@ type ChangeSet = {
 	hasToEnableTarget: boolean;
 	hasToShow: boolean;
 	hasToHide: boolean;
+	hasInteractivityChanged: boolean;
 };
 
 class Tooltip {
@@ -139,6 +140,10 @@ class Tooltip {
 		this.#target.removeAttribute('title');
 		this.#target.style.position = 'relative';
 
+		if (this.#isInteractive()) {
+			this.#target.setAttribute('aria-expanded', 'false');
+		}
+
 		this.#open = open === true ? true : undefined;
 
 		disabled ? this.#disable() : this.#enable();
@@ -160,6 +165,7 @@ class Tooltip {
 	#detectChanges({
 		content,
 		contentSelector,
+		contentActions,
 		containerClassName,
 		position,
 		offset,
@@ -186,7 +192,10 @@ class Tooltip {
 			// or when the tooltip is not yet visible. Guard with !disabled so open+disabled is a no-op.
 			hasToShow: open === true && !disabled && (!isCurrentlyShown || hasStructureChanged),
 			// Skip explicit hide when structure already removed the tooltip from the DOM.
-			hasToHide: open === false && isCurrentlyShown && !hasStructureChanged
+			hasToHide: open === false && isCurrentlyShown && !hasStructureChanged,
+			hasInteractivityChanged:
+				contentActions !== undefined &&
+				Object.keys(contentActions ?? {}).length > 0 !== this.#isInteractive()
 		};
 	}
 
@@ -232,7 +241,8 @@ class Tooltip {
 		hasToDisableTarget,
 		hasToEnableTarget,
 		hasToShow,
-		hasToHide
+		hasToHide,
+		hasInteractivityChanged
 	}: ChangeSet) {
 		if (hasStructureChanged) {
 			this.#removeTooltipFromTarget();
@@ -261,6 +271,14 @@ class Tooltip {
 		} else if (hasToHide) {
 			this.#removeTooltipFromTarget();
 		}
+
+		if (hasInteractivityChanged) {
+			if (this.#isInteractive()) {
+				this.#target?.setAttribute('aria-expanded', this.#tooltip?.parentNode ? 'true' : 'false');
+			} else {
+				this.#target?.removeAttribute('aria-expanded');
+			}
+		}
 	}
 
 	async destroy() {
@@ -274,6 +292,7 @@ class Tooltip {
 		}
 		this.#target?.style.removeProperty('position');
 		this.#target?.removeAttribute('aria-describedby');
+		this.#target?.removeAttribute('aria-expanded');
 
 		await this.#removeTooltipFromTarget(true);
 
@@ -515,6 +534,10 @@ class Tooltip {
 
 		this.#target!.setAttribute('aria-describedby', this.#id);
 
+		if (this.#isInteractive()) {
+			this.#target!.setAttribute('aria-expanded', 'true');
+		}
+
 		this.#observer!.wait(this.#tooltip!, { events: [DOMObserver.ADD] }).then(() => {
 			if (this.#destroyed) return;
 			this.#positionTooltip();
@@ -550,6 +573,10 @@ class Tooltip {
 		this.#tooltip!.remove();
 		this.#target?.removeAttribute('aria-describedby');
 
+		if (this.#isInteractive() && !this.#destroyed) {
+			this.#target?.setAttribute('aria-expanded', 'false');
+		}
+
 		if (!this.#containerClassName) {
 			this.#tooltip!.setAttribute('class', `__tooltip __tooltip-${this.#position}`);
 		}
@@ -576,6 +603,10 @@ class Tooltip {
 	#clearDelay() {
 		clearTimeout(this.#delay);
 		this.#delay = undefined;
+	}
+
+	#isInteractive() {
+		return Object.keys(this.#contentActions ?? {}).length > 0;
 	}
 
 	#transitionTooltip(entering: boolean) {

--- a/src/lib/__tests__/useTooltip.test.ts
+++ b/src/lib/__tests__/useTooltip.test.ts
@@ -1099,7 +1099,9 @@ describe('useTooltip', () => {
 			action = createAction(target, options);
 			await _enter(target);
 			const tooltip = getElement('[role=\"tooltip\"]') as HTMLElement;
-			expect(tooltip.id).toMatch(/^tooltip-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+			expect(tooltip.id).toMatch(
+				/^tooltip-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+			);
 			expect(target.getAttribute('aria-describedby')).toBe(tooltip.id);
 		});
 
@@ -1144,6 +1146,64 @@ describe('useTooltip', () => {
 		test('Does not set aria-describedby before tooltip is shown', () => {
 			action = createAction(target, options);
 			expect(target).not.toHaveAttribute('aria-describedby');
+		});
+	});
+
+	describe('useTooltip aria-expanded', () => {
+		const interactiveOptions: TooltipOptions = {
+			contentSelector: '#template',
+			contentActions: {
+				'*': { eventType: 'click', callback: vi.fn(), callbackParams: [] }
+			}
+		};
+
+		test('Sets aria-expanded="false" on init when tooltip is interactive', () => {
+			action = createAction(target, interactiveOptions);
+			expect(target).toHaveAttribute('aria-expanded', 'false');
+		});
+
+		test('Sets aria-expanded="true" when interactive tooltip is shown', async () => {
+			action = createAction(target, interactiveOptions);
+			await _enter(target);
+			expect(target).toHaveAttribute('aria-expanded', 'true');
+		});
+
+		test('Sets aria-expanded="false" when interactive tooltip is hidden', async () => {
+			action = createAction(target, interactiveOptions);
+			await _enter(target);
+			await _leave(target);
+			expect(target).toHaveAttribute('aria-expanded', 'false');
+		});
+
+		test('Removes aria-expanded on destroy', async () => {
+			action = createAction(target, interactiveOptions);
+			await action.destroy();
+			expect(target).not.toHaveAttribute('aria-expanded');
+			action = null;
+		});
+
+		test('Does not set aria-expanded when tooltip has no contentActions', () => {
+			action = createAction(target, { content: 'Hello' });
+			expect(target).not.toHaveAttribute('aria-expanded');
+		});
+
+		test('Does not set aria-expanded when contentActions is empty', () => {
+			action = createAction(target, { content: 'Hello', contentActions: {} });
+			expect(target).not.toHaveAttribute('aria-expanded');
+		});
+
+		test('Adds aria-expanded when contentActions is added via update', () => {
+			action = createAction(target, { content: 'Hello' });
+			expect(target).not.toHaveAttribute('aria-expanded');
+			action.update(interactiveOptions);
+			expect(target).toHaveAttribute('aria-expanded', 'false');
+		});
+
+		test('Removes aria-expanded when contentActions is removed via update', () => {
+			action = createAction(target, interactiveOptions);
+			expect(target).toHaveAttribute('aria-expanded', 'false');
+			action.update({ ...interactiveOptions, contentActions: null });
+			expect(target).not.toHaveAttribute('aria-expanded');
 		});
 	});
 });


### PR DESCRIPTION
## Summary

When `contentActions` is set, the tooltip exposes interactive content and the trigger behaves as an expandable widget. Screen readers now have a clear signal: `aria-expanded="false"` when the tooltip is hidden, `aria-expanded="true"` when visible. The attribute is absent when `contentActions` is empty or not provided, and is cleaned up on `destroy()`.

## Changes

- `src/lib/Tooltip.ts` — add `#isInteractive()` private method; set `aria-expanded="false"` on init, `"true"` on show, `"false"` on hide (guarded by `!this.#destroyed` to avoid conflict with `destroy()`); remove attribute on `destroy()`
- `src/lib/__tests__/useTooltip.test.ts` — 6 new tests covering init state, show/hide lifecycle, destroy cleanup, and the no-op cases (no contentActions, empty contentActions)

## Test plan

- [ ] `aria-expanded="false"` present on trigger after init when `contentActions` is non-empty
- [ ] `aria-expanded="true"` on show, `"false"` on hide
- [ ] Attribute absent when `contentActions` is not provided or empty
- [ ] Attribute fully removed after `destroy()`
- [ ] All 273 tests pass (`yarn test:ci`)

Closes #132