### PR TITLE
feat(a11y): Add aria-haspopup="dialog" to trigger when tooltip has interactive content

### DIFF
--- a/src/lib/Tooltip.ts
+++ b/src/lib/Tooltip.ts
@@ -142,6 +142,7 @@ class Tooltip {
 
 		if (this.#isInteractive()) {
 			this.#target.setAttribute('aria-expanded', 'false');
+			this.#target.setAttribute('aria-haspopup', 'dialog');
 		}
 
 		this.#open = open === true ? true : undefined;
@@ -275,8 +276,10 @@ class Tooltip {
 		if (hasInteractivityChanged) {
 			if (this.#isInteractive()) {
 				this.#target?.setAttribute('aria-expanded', this.#tooltip?.parentNode ? 'true' : 'false');
+				this.#target?.setAttribute('aria-haspopup', 'dialog');
 			} else {
 				this.#target?.removeAttribute('aria-expanded');
+				this.#target?.removeAttribute('aria-haspopup');
 			}
 		}
 	}
@@ -293,6 +296,7 @@ class Tooltip {
 		this.#target?.style.removeProperty('position');
 		this.#target?.removeAttribute('aria-describedby');
 		this.#target?.removeAttribute('aria-expanded');
+		this.#target?.removeAttribute('aria-haspopup');
 
 		await this.#removeTooltipFromTarget(true);
 

--- a/src/lib/__tests__/useTooltip.test.ts
+++ b/src/lib/__tests__/useTooltip.test.ts
@@ -1206,4 +1206,49 @@ describe('useTooltip', () => {
 			expect(target).not.toHaveAttribute('aria-expanded');
 		});
 	});
+
+	describe('useTooltip aria-haspopup', () => {
+		const interactiveOptions: TooltipOptions = {
+			contentSelector: '#template',
+			contentActions: {
+				'*': { eventType: 'click', callback: vi.fn(), callbackParams: [] }
+			}
+		};
+
+		test('Sets aria-haspopup="dialog" on init when tooltip is interactive', () => {
+			action = createAction(target, interactiveOptions);
+			expect(target).toHaveAttribute('aria-haspopup', 'dialog');
+		});
+
+		test('Removes aria-haspopup on destroy', async () => {
+			action = createAction(target, interactiveOptions);
+			await action.destroy();
+			expect(target).not.toHaveAttribute('aria-haspopup');
+			action = null;
+		});
+
+		test('Does not set aria-haspopup when tooltip has no contentActions', () => {
+			action = createAction(target, { content: 'Hello' });
+			expect(target).not.toHaveAttribute('aria-haspopup');
+		});
+
+		test('Does not set aria-haspopup when contentActions is empty', () => {
+			action = createAction(target, { content: 'Hello', contentActions: {} });
+			expect(target).not.toHaveAttribute('aria-haspopup');
+		});
+
+		test('Adds aria-haspopup when contentActions is added via update', () => {
+			action = createAction(target, { content: 'Hello' });
+			expect(target).not.toHaveAttribute('aria-haspopup');
+			action.update(interactiveOptions);
+			expect(target).toHaveAttribute('aria-haspopup', 'dialog');
+		});
+
+		test('Removes aria-haspopup when contentActions is removed via update', () => {
+			action = createAction(target, interactiveOptions);
+			expect(target).toHaveAttribute('aria-haspopup', 'dialog');
+			action.update({ ...interactiveOptions, contentActions: null });
+			expect(target).not.toHaveAttribute('aria-haspopup');
+		});
+	});
 });


### PR DESCRIPTION
## Summary

Adds `aria-haspopup="dialog"` to the trigger element when the tooltip has interactive content (i.e. `contentActions` is non-empty). This follows the same pattern as the `aria-expanded` attribute added in #132.

## Changes

- `src/lib/Tooltip.ts` — set `aria-haspopup="dialog"` in constructor and `#applyChanges()` when interactive; remove in `destroy()`
- `src/lib/__tests__/useTooltip.test.ts` — add 6 tests covering the full `aria-haspopup` lifecycle

## Test plan

- [ ] `aria-haspopup="dialog"` is set on the trigger when `contentActions` is non-empty
- [ ] `aria-haspopup` is not set when there are no `contentActions` or they are empty
- [ ] `aria-haspopup` is added/removed when `contentActions` is added/removed via `update()`
- [ ] `aria-haspopup` is removed on `destroy()`

Closes #133