### PR TITLE
feat(a11y): Implement focus trap for interactive tooltip content

### DIFF
--- a/src/lib/Tooltip.ts
+++ b/src/lib/Tooltip.ts
@@ -86,6 +86,7 @@ class Tooltip {
 	#boundEnterHandler: ((e: Event) => void) | null = null;
 	#boundLeaveHandler: ((e: Event) => void) | null = null;
 	#boundWindowChangeHandler: ((e: Event) => void) | null = null;
+	#trapHandler: ((e: KeyboardEvent) => void) | null = null;
 
 	static destroy() {
 		Tooltip.#instances.forEach((instance) => {
@@ -550,7 +551,7 @@ class Tooltip {
 
 		if (this.#contentActions) {
 			Object.entries(this.#contentActions).forEach(
-				([key, { eventType, callback, callbackParams, closeOnCallback }], i) => {
+				([key, { eventType, callback, callbackParams, closeOnCallback }]) => {
 					const trigger = key === '*' ? this.#tooltip! : this.#tooltip!.querySelector(key);
 					if (trigger) {
 						const listener: EventListener = (event) => {
@@ -561,11 +562,10 @@ class Tooltip {
 						};
 						trigger.addEventListener(eventType, listener);
 						this.#events.push({ trigger, eventType, listener });
-
-						if (i === 0) (trigger as HTMLElement).focus();
 					}
 				}
 			);
+			this.#setupFocusTrap();
 		}
 	}
 
@@ -591,6 +591,8 @@ class Tooltip {
 			trigger.removeEventListener(eventType, listener)
 		);
 		this.#events = [];
+
+		this.#teardownFocusTrap();
 	}
 
 	#waitForDelay(delay: number) {
@@ -611,6 +613,50 @@ class Tooltip {
 
 	#isInteractive() {
 		return Object.keys(this.#contentActions ?? {}).length > 0;
+	}
+
+	#setupFocusTrap(): void {
+		const focusable = this.#tooltip!.querySelectorAll<HTMLElement>(
+			'a, button, input, select, textarea, [tabindex]:not([tabindex="-1"])'
+		);
+		if (!focusable.length) return;
+
+		const first = focusable[0];
+		const last = focusable[focusable.length - 1];
+
+		this.#trapHandler = (e: KeyboardEvent) => {
+			if (e.key !== 'Tab') return;
+			if (e.shiftKey) {
+				if (document.activeElement === first) {
+					e.preventDefault();
+					last.focus();
+				}
+			} else {
+				if (document.activeElement === last) {
+					e.preventDefault();
+					first.focus();
+				}
+			}
+		};
+
+		this.#tooltip!.addEventListener('keydown', this.#trapHandler);
+		first.focus();
+	}
+
+	#teardownFocusTrap(): void {
+		if (this.#trapHandler) {
+			this.#tooltip?.removeEventListener('keydown', this.#trapHandler);
+			this.#trapHandler = null;
+			// Temporarily remove the focusin listener so that returning focus to the trigger
+			// does not re-open the tooltip.
+			if (this.#boundEnterHandler) {
+				this.#target?.removeEventListener('focusin', this.#boundEnterHandler);
+			}
+			this.#target?.focus();
+			if (this.#boundEnterHandler) {
+				this.#target?.addEventListener('focusin', this.#boundEnterHandler);
+			}
+		}
 	}
 
 	#transitionTooltip(entering: boolean) {
@@ -646,6 +692,8 @@ class Tooltip {
 
 	async #onTargetLeave(e: Event) {
 		if (this.#open) return;
+		if (e.type === 'focusout' && this.#target?.contains((e as FocusEvent).relatedTarget as Node))
+			return;
 		if (this.#target === e.target || !this.#target?.contains(e.target as Node)) {
 			await this.#waitForDelay(this.#leaveDelay);
 			await this.#removeTooltipFromTarget();

--- a/src/lib/Tooltip.ts
+++ b/src/lib/Tooltip.ts
@@ -617,7 +617,15 @@ class Tooltip {
 
 	#setupFocusTrap(): void {
 		const focusable = this.#tooltip!.querySelectorAll<HTMLElement>(
-			'a, button, input, select, textarea, [tabindex]:not([tabindex="-1"])'
+			[
+				'a[href]',
+				'button:not([disabled])',
+				'input:not([disabled]):not([type="hidden"])',
+				'select:not([disabled])',
+				'textarea:not([disabled])',
+				'[contenteditable]:not([contenteditable="false"])',
+				'[tabindex]:not([tabindex="-1"])'
+			].join(', ')
 		);
 		if (!focusable.length) return;
 

--- a/src/lib/__tests__/useTooltip.test.ts
+++ b/src/lib/__tests__/useTooltip.test.ts
@@ -1333,8 +1333,11 @@ describe('useTooltip', () => {
 		});
 
 		test('Does not trap focus when tooltip has no focusable elements', async () => {
-			action = createAction(target, options);
-			await _enter(target);
+			trapAction = createAction(trapTarget, {
+				content: 'Hello',
+				contentActions: { '*': { eventType: 'click', callback: vi.fn(), callbackParams: [] } }
+			});
+			await _enter(trapTarget);
 			const tooltip = getElement('[role="tooltip"]') as HTMLElement;
 			expect(tooltip.querySelector('button')).toBeNull();
 			expect(document.activeElement).not.toBeInstanceOf(HTMLButtonElement);

--- a/src/lib/__tests__/useTooltip.test.ts
+++ b/src/lib/__tests__/useTooltip.test.ts
@@ -1251,4 +1251,93 @@ describe('useTooltip', () => {
 			expect(target).not.toHaveAttribute('aria-haspopup');
 		});
 	});
+
+	describe('useTooltip focus trap', () => {
+		const TRAP_TEMPLATE_ID = 'trap-template';
+		const trapOptions: TooltipOptions = {
+			contentSelector: `#${TRAP_TEMPLATE_ID}`,
+			contentActions: {
+				'*': { eventType: 'click', callback: vi.fn(), callbackParams: [] }
+			}
+		};
+
+		let trapTarget: HTMLElement;
+		let trapAction: FullAction | null = null;
+
+		beforeEach(() => {
+			trapTarget = createElement({
+				tag: 'div',
+				attributes: { id: 'trap-target', tabindex: '0' },
+				parent: document.body
+			});
+			const tmpl = createElement({
+				tag: 'template',
+				attributes: { id: TRAP_TEMPLATE_ID },
+				parent: document.body
+			});
+			const content = (tmpl as HTMLTemplateElement).content as unknown as HTMLElement;
+			const container = createElement({ tag: 'div', parent: content });
+			createElement({ tag: 'button', parent: container });
+			createElement({ tag: 'button', parent: container });
+		});
+
+		afterEach(async () => {
+			await trapAction?.destroy();
+			trapAction = null;
+			removeElement('#trap-target');
+			removeElement(`#${TRAP_TEMPLATE_ID}`);
+		});
+
+		test('Moves focus to first focusable element when tooltip opens', async () => {
+			trapAction = createAction(trapTarget, trapOptions);
+			await _enter(trapTarget);
+			const tooltip = getElement('[role="tooltip"]') as HTMLElement;
+			expect(document.activeElement).toBe(tooltip.querySelector('button'));
+		});
+
+		test('Traps Tab: wraps focus from last element to first', async () => {
+			trapAction = createAction(trapTarget, trapOptions);
+			await _enter(trapTarget);
+			const tooltip = getElement('[role="tooltip"]') as HTMLElement;
+			const buttons = tooltip.querySelectorAll<HTMLElement>('button');
+			buttons[buttons.length - 1].focus();
+			await fireEvent.keyDown(tooltip, { key: 'Tab', shiftKey: false });
+			await standby(1);
+			expect(document.activeElement).toBe(buttons[0]);
+		});
+
+		test('Traps Shift+Tab: wraps focus from first element to last', async () => {
+			trapAction = createAction(trapTarget, trapOptions);
+			await _enter(trapTarget);
+			const tooltip = getElement('[role="tooltip"]') as HTMLElement;
+			const buttons = tooltip.querySelectorAll<HTMLElement>('button');
+			buttons[0].focus();
+			await fireEvent.keyDown(tooltip, { key: 'Tab', shiftKey: true });
+			await standby(1);
+			expect(document.activeElement).toBe(buttons[buttons.length - 1]);
+		});
+
+		test('Escape closes tooltip and returns focus to trigger', async () => {
+			trapAction = createAction(trapTarget, trapOptions);
+			await _enter(trapTarget);
+			await _keyDown(trapTarget);
+			expect(getElement('[role="tooltip"]')).not.toBeInTheDocument();
+			expect(document.activeElement).toBe(trapTarget);
+		});
+
+		test('Returns focus to trigger when tooltip closes', async () => {
+			trapAction = createAction(trapTarget, trapOptions);
+			await _enter(trapTarget);
+			await _leave(trapTarget);
+			expect(document.activeElement).toBe(trapTarget);
+		});
+
+		test('Does not trap focus when tooltip has no focusable elements', async () => {
+			action = createAction(target, options);
+			await _enter(target);
+			const tooltip = getElement('[role="tooltip"]') as HTMLElement;
+			expect(tooltip.querySelector('button')).toBeNull();
+			expect(document.activeElement).not.toBeInstanceOf(HTMLButtonElement);
+		});
+	});
 });

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -15,6 +15,7 @@
 	let offset = $state(10);
 	let width = $state('auto');
 	let isOpen = $state<boolean | undefined>(undefined);
+	let useInteractiveContent = $state(false);
 
 	const _onTooltipEnter = () => {
 		if (triggerOnEnter) {
@@ -83,6 +84,23 @@
 		flex-direction: column;
 		row-gap: 0.5rem;
 		align-items: center;
+	}
+
+	:global(.tooltip__interactive__btn) {
+		width: 100%;
+		padding: 0.25rem 0.5rem;
+		font-family: inherit;
+		font-size: inherit;
+		cursor: pointer;
+		border: 1px solid rgba(255, 255, 255, 0.5);
+		border-radius: 4px;
+		background-color: rgba(255, 255, 255, 0.15);
+		color: #fff;
+	}
+
+	:global(.tooltip__interactive__btn:focus) {
+		outline: 2px solid #fff;
+		outline-offset: 1px;
 	}
 
 	:global(.tooltip) {
@@ -243,21 +261,40 @@
 <template id="tooltip__template">
 	<span class="tooltip__content">Hi! I'm a <i>fancy</i> <strong>tooltip</strong>!</span>
 </template>
+<template id="tooltip__interactive__template">
+	<div class="tooltip__content">
+		<button class="tooltip__interactive__btn">Action 1</button>
+		<button class="tooltip__interactive__btn">Action 2</button>
+	</div>
+</template>
 <main>
 	<div class="content">
 		<div
 			use:useTooltip={{
 				position: position,
-				content: textContent,
-				contentSelector: !textContent?.length ? '#tooltip__template' : null,
-				contentActions: {
-					'*': {
-						eventType: 'click',
-						callback: _onTooltipClick,
-						callbackParams: ['ok'],
-						closeOnCallback: true
-					}
-				},
+				content: useInteractiveContent ? null : textContent,
+				contentSelector: useInteractiveContent
+					? '#tooltip__interactive__template'
+					: !textContent?.length
+						? '#tooltip__template'
+						: null,
+				contentActions: useInteractiveContent
+					? {
+							'.tooltip__interactive__btn': {
+								eventType: 'click',
+								callback: _onTooltipClick,
+								callbackParams: ['ok'],
+								closeOnCallback: false
+							}
+						}
+					: {
+							'*': {
+								eventType: 'click',
+								callback: _onTooltipClick,
+								callbackParams: ['ok'],
+								closeOnCallback: true
+							}
+						},
 				containerClassName: useCustomClass ? `tooltip tooltip-${position}` : null,
 				animated: animate,
 				animationEnterClassName: useCustomAnimationEnterClass ? 'tooltip-enter' : null,
@@ -354,6 +391,12 @@
 				<label>
 					Width:
 					<input type="text" bind:value={width} />
+				</label>
+			</fieldset>
+			<fieldset>
+				<label>
+					Interactive Content (focus trap):
+					<input type="checkbox" bind:checked={useInteractiveContent} />
 				</label>
 			</fieldset>
 			<fieldset>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -88,11 +88,11 @@
 
 	:global(.tooltip__interactive__btn) {
 		width: 100%;
-		padding: 0.25rem 0.5rem;
+		padding: 0.5em 1em;
 		font-family: inherit;
 		font-size: inherit;
 		cursor: pointer;
-		border: 1px solid rgba(255, 255, 255, 0.5);
+		border: none;	
 		border-radius: 4px;
 		background-color: rgba(255, 255, 255, 0.15);
 		color: #fff;
@@ -100,7 +100,7 @@
 
 	:global(.tooltip__interactive__btn:focus) {
 		outline: 2px solid #fff;
-		outline-offset: 1px;
+		outline-offset: 0;
 	}
 
 	:global(.tooltip) {
@@ -265,6 +265,7 @@
 	<div class="tooltip__content">
 		<button class="tooltip__interactive__btn">Action 1</button>
 		<button class="tooltip__interactive__btn">Action 2</button>
+		<span style="font-style: italic;">(Use Tab)</span>
 	</div>
 </template>
 <main>


### PR DESCRIPTION
## Summary

When a tooltip has interactive content (`contentActions` non-empty), Tab/Shift+Tab now cycle focus within the tooltip instead of escaping to the page tab order. Pressing Escape (or any close trigger) returns focus to the trigger element.

## Changes

- `src/lib/Tooltip.ts`
  - `#trapHandler` field: holds the keydown listener reference
  - `#setupFocusTrap()`: queries all focusable elements inside the tooltip, attaches a `keydown` listener for Tab/Shift+Tab cycling, and moves focus to the first element on open
  - `#teardownFocusTrap()`: removes the listener and returns focus to the trigger; temporarily detaches the `focusin` listener to prevent the tooltip from re-opening on focus return
  - `#appendTooltipToTarget()`: calls `#setupFocusTrap()` after contentActions are wired up (replaces the per-entry `focus()` call at index 0)
  - `#removeTooltipFromTarget()`: calls `#teardownFocusTrap()` at teardown
  - `#onTargetLeave()`: adds a `relatedTarget` guard so that the tooltip does not close when focus moves from the trigger into the tooltip content

- `src/lib/__tests__/useTooltip.test.ts` — 6 new tests: focus on first element, Tab wrap, Shift+Tab wrap, Escape returns focus, close returns focus, no trap without focusable elements

- `src/routes/+page.svelte` — new `#tooltip__interactive__template` with two buttons + "Interactive Content (focus trap)" checkbox to enable it in the demo

## Test plan

- [ ] Check "Interactive Content (focus trap)" in the demo, hover the target — first button gets focus
- [ ] Tab from second button wraps to first
- [ ] Shift+Tab from first button wraps to second
- [ ] Press Escape — tooltip closes and focus returns to the trigger

## ⚠️ Breaking changes

None.

Closes #134