### PR TITLE
test(a11y): Add regression tests for focusout guard

### DIFF
--- a/src/lib/__tests__/useTooltip.test.ts
+++ b/src/lib/__tests__/useTooltip.test.ts
@@ -1252,6 +1252,36 @@ describe('useTooltip', () => {
 		});
 	});
 
+	describe('useTooltip focusout guard', () => {
+		test('Does not close tooltip when focusout fires with relatedTarget inside the tooltip', async () => {
+			action = createAction(target, options);
+			await _enter(target);
+			const tooltip = getElement('[role="tooltip"]') as HTMLElement;
+			const contentEl = getElement('#content') as HTMLElement;
+			await fireEvent.focusOut(target, { relatedTarget: contentEl });
+			await standby(1);
+			expect(tooltip).toBeInTheDocument();
+		});
+
+		test('Closes tooltip when focusout fires with relatedTarget outside the tooltip', async () => {
+			action = createAction(target, options);
+			await _enter(target);
+			const tooltip = getElement('[role="tooltip"]') as HTMLElement;
+			await fireEvent.focusOut(target, { relatedTarget: document.body });
+			await standby(1);
+			expect(tooltip).not.toBeInTheDocument();
+		});
+
+		test('Closes tooltip when focusout fires with no relatedTarget', async () => {
+			action = createAction(target, options);
+			await _enter(target);
+			const tooltip = getElement('[role="tooltip"]') as HTMLElement;
+			await fireEvent.focusOut(target, { relatedTarget: null });
+			await standby(1);
+			expect(tooltip).not.toBeInTheDocument();
+		});
+	});
+
 	describe('useTooltip focus trap', () => {
 		const TRAP_TEMPLATE_ID = 'trap-template';
 		const trapOptions: TooltipOptions = {


### PR DESCRIPTION
## Summary

The `focusout` guard (introduced in #169) prevents the tooltip from closing when focus moves from the trigger into the tooltip content. This PR adds three dedicated regression tests to formally document and protect that behavior.

## Changes

- `src/lib/__tests__/useTooltip.test.ts` — new `describe('useTooltip focusout guard')` block with 3 tests:
  - `focusout` with `relatedTarget` inside the tooltip → tooltip stays visible
  - `focusout` with `relatedTarget` outside the tooltip → tooltip closes
  - `focusout` with no `relatedTarget` → tooltip closes

## Test plan

- [ ] All 3 tests pass (324 total, all green)

Closes #135