### PR TITLE
fix(tooltip): Skip leave animation on structural rebuild to prevent race condition

### DIFF
--- a/src/lib/Tooltip.ts
+++ b/src/lib/Tooltip.ts
@@ -247,7 +247,7 @@ class Tooltip {
 		hasInteractivityChanged
 	}: ChangeSet) {
 		if (hasStructureChanged) {
-			this.#removeTooltipFromTarget();
+			this.#removeTooltipFromTarget(true);
 			this.#createTooltip();
 		}
 		if (hasStructureChanged || hasContainerClassNameChanged) {


### PR DESCRIPTION
## Summary

When a prop that triggers a structural rebuild (e.g. `position`) changes while the tooltip is visible with `animated: true`, the leave animation was running concurrently with the new tooltip creation. By the time the animation cleanup fired, `this.#tooltip` already pointed to the new element — causing `.remove()` to delete the newly-shown tooltip, making it disappear immediately after the enter animation.

## Changes

- `src/lib/Tooltip.ts` — pass `skipAnimation=true` to `#removeTooltipFromTarget()` in `#applyChanges()` when `hasStructureChanged` is true, making the old tooltip removal synchronous before rebuilding

## Test plan

- [ ] Enable animations in the demo, hover the target to show the tooltip, then change the position — tooltip should remain visible without disappearing after the enter animation
- [ ] All 324 existing tests pass

## Root cause

```
#applyChanges() {
    if (hasStructureChanged) {
        this.#removeTooltipFromTarget();  // async — was NOT awaited
        this.#createTooltip();            // immediately replaces this.#tooltip
    }
}
```

The leave animation closure captured `this.#tooltip` by reference. When cleanup ran after the animation, `this.#tooltip` was the *new* element — `.remove()` erased it.

Closes #137