### PR TITLE
fix(tooltip): Close tooltip on scroll inside ancestor scroll containers

### DIFF
--- a/src/lib/Tooltip.ts
+++ b/src/lib/Tooltip.ts
@@ -341,14 +341,12 @@ class Tooltip {
 	}
 
 	#getScrollableAncestors(): Element[] {
+		const scrollable = ['auto', 'scroll'];
 		const ancestors: Element[] = [];
 		let el: Element | null = this.#target?.parentElement ?? null;
 		while (el && el !== document.documentElement) {
 			const { overflowX, overflowY } = window.getComputedStyle(el);
-			if (
-				(overflowX !== 'visible' && overflowX !== 'clip') ||
-				(overflowY !== 'visible' && overflowY !== 'clip')
-			) {
+			if (scrollable.includes(overflowX) || scrollable.includes(overflowY)) {
 				ancestors.push(el);
 			}
 			el = el.parentElement;

--- a/src/lib/Tooltip.ts
+++ b/src/lib/Tooltip.ts
@@ -87,6 +87,7 @@ class Tooltip {
 	#boundLeaveHandler: ((e: Event) => void) | null = null;
 	#boundWindowChangeHandler: ((e: Event) => void) | null = null;
 	#trapHandler: ((e: KeyboardEvent) => void) | null = null;
+	#scrollableAncestors: Element[] = [];
 
 	static destroy() {
 		Tooltip.#instances.forEach((instance) => {
@@ -332,6 +333,27 @@ class Tooltip {
 		window.addEventListener('keydown', this.#boundWindowChangeHandler);
 		window.addEventListener('resize', this.#boundWindowChangeHandler);
 		window.addEventListener('scroll', this.#boundWindowChangeHandler);
+
+		this.#scrollableAncestors = this.#getScrollableAncestors();
+		this.#scrollableAncestors.forEach((ancestor) => {
+			ancestor.addEventListener('scroll', this.#boundWindowChangeHandler!);
+		});
+	}
+
+	#getScrollableAncestors(): Element[] {
+		const ancestors: Element[] = [];
+		let el: Element | null = this.#target?.parentElement ?? null;
+		while (el && el !== document.documentElement) {
+			const { overflowX, overflowY } = window.getComputedStyle(el);
+			if (
+				(overflowX !== 'visible' && overflowX !== 'clip') ||
+				(overflowY !== 'visible' && overflowY !== 'clip')
+			) {
+				ancestors.push(el);
+			}
+			el = el.parentElement;
+		}
+		return ancestors;
 	}
 
 	#disable() {
@@ -358,6 +380,11 @@ class Tooltip {
 			window.removeEventListener('keydown', this.#boundWindowChangeHandler);
 			window.removeEventListener('resize', this.#boundWindowChangeHandler);
 			window.removeEventListener('scroll', this.#boundWindowChangeHandler);
+
+			this.#scrollableAncestors.forEach((ancestor) => {
+				ancestor.removeEventListener('scroll', this.#boundWindowChangeHandler!);
+			});
+			this.#scrollableAncestors = [];
 		}
 
 		this.#boundWindowChangeHandler = null;

--- a/src/lib/__tests__/useTooltip.test.ts
+++ b/src/lib/__tests__/useTooltip.test.ts
@@ -131,6 +131,55 @@ describe('useTooltip', () => {
 			spy.mockRestore();
 		});
 
+		test('Removes tooltip on scroll inside a scrollable ancestor container', async () => {
+			const container = createElement({ tag: 'div', attributes: { id: 'container' }, parent: document.body });
+			container.style.overflowY = 'auto';
+			container.appendChild(target);
+
+			action = createAction(target, options);
+			await _enter(target);
+			expect(getElement('#content')).toBeInTheDocument();
+
+			await fireEvent.scroll(container);
+			expect(getElement('#content')).not.toBeInTheDocument();
+
+			await action.destroy();
+			action = null;
+			removeElement('#container');
+		});
+
+		test('Does not remove tooltip on scroll inside a non-scrollable ancestor container', async () => {
+			const container = createElement({ tag: 'div', attributes: { id: 'container' }, parent: document.body });
+			// No overflow set — default is visible on both axes, not a scroll container
+			container.appendChild(target);
+
+			action = createAction(target, options);
+			await _enter(target);
+			expect(getElement('#content')).toBeInTheDocument();
+
+			await fireEvent.scroll(container);
+			expect(getElement('#content')).toBeInTheDocument();
+
+			await action.destroy();
+			action = null;
+			removeElement('#container');
+		});
+
+		test('Removes ancestor scroll listeners on destroy', async () => {
+			const container = createElement({ tag: 'div', attributes: { id: 'container' }, parent: document.body });
+			container.style.overflowY = 'auto';
+			container.appendChild(target);
+
+			action = createAction(target, options);
+			const spy = vi.spyOn(container, 'removeEventListener');
+			await action.destroy();
+			expect(spy).toHaveBeenCalledWith('scroll', expect.any(Function));
+			spy.mockRestore();
+
+			action = null;
+			removeElement('#container');
+		});
+
 		test('Restores original title attribute on destroy', async () => {
 			target.setAttribute('title', 'original title');
 			action = createAction(target, { content: 'tooltip' });

--- a/src/lib/__tests__/useTooltip.test.ts
+++ b/src/lib/__tests__/useTooltip.test.ts
@@ -132,7 +132,11 @@ describe('useTooltip', () => {
 		});
 
 		test('Removes tooltip on scroll inside a scrollable ancestor container', async () => {
-			const container = createElement({ tag: 'div', attributes: { id: 'container' }, parent: document.body });
+			const container = createElement({
+				tag: 'div',
+				attributes: { id: 'container' },
+				parent: document.body
+			});
 			container.style.overflowY = 'auto';
 			container.appendChild(target);
 
@@ -149,7 +153,11 @@ describe('useTooltip', () => {
 		});
 
 		test('Does not remove tooltip on scroll inside a non-scrollable ancestor container', async () => {
-			const container = createElement({ tag: 'div', attributes: { id: 'container' }, parent: document.body });
+			const container = createElement({
+				tag: 'div',
+				attributes: { id: 'container' },
+				parent: document.body
+			});
 			// No overflow set — default is visible on both axes, not a scroll container
 			container.appendChild(target);
 
@@ -166,7 +174,11 @@ describe('useTooltip', () => {
 		});
 
 		test('Removes ancestor scroll listeners on destroy', async () => {
-			const container = createElement({ tag: 'div', attributes: { id: 'container' }, parent: document.body });
+			const container = createElement({
+				tag: 'div',
+				attributes: { id: 'container' },
+				parent: document.body
+			});
 			container.style.overflowY = 'auto';
 			container.appendChild(target);
 


### PR DESCRIPTION
## Summary

`window.scroll` was the only scroll event handled — scrolling a parent `overflow: auto/scroll` container left the tooltip open while the trigger moved, inconsistent with the existing window-scroll behaviour (which closes the tooltip).

## Changes

- `src/lib/Tooltip.ts` — new `#scrollableAncestors` field, `#getScrollableAncestors()` method that walks the DOM from the target and collects ancestors whose computed `overflowX` or `overflowY` is `auto` or `scroll`; `#enableWindow()` attaches the existing `#onWindowChange` handler to each; `#disableWindow()` removes those listeners and clears the list

## Implementation note

`#getScrollableAncestors()` uses an inclusion list `['auto', 'scroll']` rather than excluding `'visible'`/`'clip'` because jsdom returns `''` (empty string) for unset overflow sub-properties, which would otherwise create false positives.

## Test plan

- [ ] Place a trigger inside an `overflow: auto` container, hover, scroll the container — tooltip closes
- [ ] Place a trigger inside a plain container, hover, scroll — tooltip stays open
- [ ] Destroy the action — no ancestor scroll listeners leak

## Breaking changes

None.

Closes #138