### PR TITLE
fix(demo): Make demo page fully responsive

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -344,31 +344,26 @@
 		column-gap: 1rem;
 	}
 
-	.settings__form input {
+	.settings__form input:not([type='checkbox']),
+	.settings__form textarea,
+	.settings__form select {
 		margin: 0;
-		max-width: 100px;
-		height: 30px;
+		width: 100px;
 		font-family: inherit;
 		font-size: inherit;
+	}
+
+	.settings__form input:not([type='checkbox']),
+	.settings__form select {
+		height: 30px;
 	}
 
 	.settings__form textarea {
-		margin: 0;
 		padding: 0.5em;
-		max-width: 100px;
-		font-family: inherit;
-		font-size: inherit;
-	}
-
-	.settings__form select {
-		margin: 0;
-		max-width: 80px;
-		height: 30px;
-		font-family: inherit;
-		font-size: inherit;
 	}
 
 	.settings__form input[type='checkbox'] {
+		margin: 0;
 		padding: 0;
 	}
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -216,10 +216,18 @@
 			min-width: 420px;
 		}
 
-		.settings__form input,
-		.settings__form textarea,
-		.settings__form select {
-			max-width: 140px;
+		.settings__form label {
+			column-gap: 0.75rem;
+		}
+
+		.settings__form label > :last-child:not(input[type='checkbox']) {
+			flex: 1;
+			max-width: none;
+			width: 100%;
+		}
+
+		.settings__form label > :first-child {
+			flex-shrink: 0;
 		}
 	}
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -216,18 +216,11 @@
 			min-width: 420px;
 		}
 
-		.settings__form label:not(:has(input[type='checkbox'])) {
-			display: grid;
-			grid-template-columns: auto 1fr;
-			column-gap: 0.75rem;
-			width: 100%;
-		}
-
 		.settings__form input:not([type='checkbox']),
 		.settings__form textarea,
 		.settings__form select {
+			flex: 1;
 			max-width: none;
-			width: 100%;
 		}
 
 		.settings__form fieldset:last-child {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -220,6 +220,7 @@
 			display: grid;
 			grid-template-columns: auto 1fr;
 			column-gap: 0.75rem;
+			width: 100%;
 		}
 
 		.settings__form input:not([type='checkbox']),

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -326,7 +326,7 @@
 		padding: 0;
 	}
 
-	.settings__form fieldset:last-child {
+	.settings__form__actions {
 		display: flex;
 		justify-content: flex-end;
 	}
@@ -378,6 +378,11 @@
 		<span style="font-style: italic;">(Use Tab)</span>
 	</div>
 </template>
+<svelte:window
+	onkeydown={(e) => {
+		if (e.key === 'Escape') settingsOpen = false;
+	}}
+/>
 <main>
 	<button
 		class="burger"
@@ -389,8 +394,12 @@
 		<span></span>
 		<span></span>
 	</button>
-	<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
-	<div class="backdrop" class:open={settingsOpen} onclick={() => (settingsOpen = false)}></div>
+	<div
+		class="backdrop"
+		class:open={settingsOpen}
+		onclick={() => (settingsOpen = false)}
+		role="presentation"
+	></div>
 	<div class="content">
 		<div
 			use:useTooltip={{
@@ -544,7 +553,7 @@
 					<input type="checkbox" bind:checked={isDisabled} />
 				</label>
 			</fieldset>
-			<fieldset>
+			<fieldset class="settings__form__actions">
 				<button type="button" onclick={() => (isOpen = !isOpen)} disabled={isDisabled}>
 					{isOpen === true ? 'Masquer la tooltip' : 'Afficher la tooltip'}
 				</button>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -222,11 +222,6 @@
 			flex: 0 0 200px;
 			max-width: none;
 		}
-
-		.settings__form fieldset:last-child {
-			display: flex;
-			justify-content: flex-end;
-		}
 	}
 
 	.burger {
@@ -330,6 +325,11 @@
 		border: none;
 		padding: 0;
 	}
+    
+    .settings__form fieldset:last-child {
+        display: flex;
+        justify-content: flex-end;
+    }
 
 	.settings__form label {
 		display: flex;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -330,6 +330,7 @@
 	.settings__form textarea {
 		margin: 0;
 		padding: 0.5em;
+		max-width: 100px;
 		font-family: inherit;
 		font-size: inherit;
 	}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -17,6 +17,7 @@
 	let isOpen = $state<boolean | undefined>(undefined);
 	let useInteractiveContent = $state(false);
 	let touchBehavior = $state<'hover' | 'toggle' | undefined>(undefined);
+	let settingsOpen = $state(false);
 
 	const _onTooltipEnter = () => {
 		if (triggerOnEnter) {
@@ -209,34 +210,90 @@
 		padding: 2rem;
 	}
 
+	.burger {
+		display: none;
+	}
+
+	.backdrop {
+		display: none;
+	}
+
+	.settings__close {
+		display: none;
+	}
+
 	@media screen and (max-width: 480px) {
-		main {
+		.burger {
+			display: flex;
 			flex-direction: column;
-			align-items: stretch;
+			justify-content: space-between;
+			position: fixed;
+			top: 1rem;
+			right: 1rem;
+			z-index: 200;
+			width: 2rem;
+			height: 1.5rem;
+			padding: 0;
+			background: none;
+			border: none;
+			cursor: pointer;
 		}
 
-		.content {
-			min-height: 50vh;
-			min-height: 50svh;
+		.burger span {
+			display: block;
+			width: 100%;
+			height: 2px;
+			background-color: white;
+			border-radius: 2px;
+		}
+
+		.backdrop {
+			display: block;
+			position: fixed;
+			inset: 0;
+			background: rgba(0, 0, 0, 0.5);
+			z-index: 300;
+			opacity: 0;
+			pointer-events: none;
+			transition: opacity 0.25s ease;
+		}
+
+		.backdrop.open {
+			opacity: 1;
+			pointer-events: auto;
 		}
 
 		.settings {
-			display: flex;
-			width: 100%;
+			position: fixed;
+			top: 0;
+			right: 0;
+			width: min(320px, 90vw);
 			min-width: 0;
 			min-height: 0;
-			max-height: 50vh;
-			max-height: 50svh;
-			padding: 1rem 1.5rem;
+			height: 100vh;
+			height: 100svh;
+			z-index: 400;
+			transform: translateX(100%);
+			transition: transform 0.25s ease;
 			overflow-y: auto;
+			padding: 1.5rem;
 		}
 
-		.settings h1 {
-			margin-bottom: 0.75rem;
+		.settings.open {
+			transform: translateX(0);
 		}
 
-		.settings__form {
-			row-gap: 0.75rem;
+		.settings__close {
+			display: flex;
+			align-self: flex-end;
+			background: none;
+			border: none;
+			color: white;
+			font-size: 1.25rem;
+			cursor: pointer;
+			padding: 0;
+			margin-bottom: 0.5rem;
+			line-height: 1;
 		}
 	}
 
@@ -307,6 +364,18 @@
 	</div>
 </template>
 <main>
+	<button
+		class="burger"
+		aria-label="Open settings"
+		aria-expanded={settingsOpen}
+		onclick={() => (settingsOpen = true)}
+	>
+		<span></span>
+		<span></span>
+		<span></span>
+	</button>
+	<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+	<div class="backdrop" class:open={settingsOpen} onclick={() => (settingsOpen = false)}></div>
 	<div class="content">
 		<div
 			use:useTooltip={{
@@ -353,7 +422,8 @@
 			{touchBehavior ? 'Touch me' : 'Hover me'}
 		</div>
 	</div>
-	<div class="settings">
+	<div class="settings" class:open={settingsOpen}>
+		<button class="settings__close" aria-label="Close settings" onclick={() => (settingsOpen = false)}>✕</button>
 		<h1>Settings</h1>
 		<form class="settings__form">
 			<fieldset>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -245,8 +245,8 @@
 			top: 1rem;
 			right: 1rem;
 			z-index: 200;
-			width: 2rem;
-			height: 1.5rem;
+			width: 1rem;
+			height: 1rem;
 			padding: 0;
 			background: none;
 			border: none;
@@ -325,11 +325,11 @@
 		border: none;
 		padding: 0;
 	}
-    
-    .settings__form fieldset:last-child {
-        display: flex;
-        justify-content: flex-end;
-    }
+
+	.settings__form fieldset:last-child {
+		display: flex;
+		justify-content: flex-end;
+	}
 
 	.settings__form label {
 		display: flex;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -210,6 +210,19 @@
 		padding: 2rem;
 	}
 
+	@media screen and (min-width: 1024px) {
+		.settings {
+			width: 420px;
+			min-width: 420px;
+		}
+
+		.settings__form input,
+		.settings__form textarea,
+		.settings__form select {
+			max-width: 140px;
+		}
+	}
+
 	.burger {
 		display: none;
 	}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -44,7 +44,8 @@
 		align-items: center;
 		margin: 0;
 		padding: 0;
-		height: 100%;
+		min-height: 100vh;
+		min-height: 100svh;
 		background-color: #617899;
 		font-family:
 			monospace,
@@ -54,6 +55,7 @@
 	}
 
 	.content {
+		flex: 1;
 		display: flex;
 		flex-direction: column;
 		align-items: center;
@@ -208,8 +210,33 @@
 	}
 
 	@media screen and (max-width: 480px) {
+		main {
+			flex-direction: column;
+			align-items: stretch;
+		}
+
+		.content {
+			min-height: 50vh;
+			min-height: 50svh;
+		}
+
 		.settings {
-			display: none;
+			display: flex;
+			width: 100%;
+			min-width: 0;
+			min-height: 0;
+			max-height: 50vh;
+			max-height: 50svh;
+			padding: 1rem 1.5rem;
+			overflow-y: auto;
+		}
+
+		.settings h1 {
+			margin-bottom: 0.75rem;
+		}
+
+		.settings__form {
+			row-gap: 0.75rem;
 		}
 	}
 
@@ -323,7 +350,7 @@
 			}}
 			class="target"
 		>
-			Hover me
+			{touchBehavior ? 'Touch me' : 'Hover me'}
 		</div>
 	</div>
 	<div class="settings">

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -218,7 +218,7 @@
 
 		.settings__form label:not(:has(input[type='checkbox'])) {
 			display: grid;
-			grid-template-columns: 1fr 160px;
+			grid-template-columns: auto 1fr;
 			column-gap: 0.75rem;
 		}
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -42,7 +42,7 @@
 		position: relative;
 		display: flex;
 		justify-content: center;
-		align-items: center;
+		align-items: stretch;
 		margin: 0;
 		padding: 0;
 		min-height: 100vh;
@@ -60,6 +60,7 @@
 		display: flex;
 		flex-direction: column;
 		align-items: center;
+		justify-content: center;
 		width: 100%;
 	}
 
@@ -202,7 +203,6 @@
 		overflow: hidden auto;
 		width: 320px;
 		min-width: 320px;
-		min-height: 100%;
 		display: flex;
 		flex-direction: column;
 		color: white;
@@ -423,7 +423,11 @@
 		</div>
 	</div>
 	<div class="settings" class:open={settingsOpen}>
-		<button class="settings__close" aria-label="Close settings" onclick={() => (settingsOpen = false)}>✕</button>
+		<button
+			class="settings__close"
+			aria-label="Close settings"
+			onclick={() => (settingsOpen = false)}>✕</button
+		>
 		<h1>Settings</h1>
 		<form class="settings__form">
 			<fieldset>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -219,7 +219,7 @@
 		.settings__form input:not([type='checkbox']),
 		.settings__form textarea,
 		.settings__form select {
-			flex: 1;
+			flex: 0 0 200px;
 			max-width: none;
 		}
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -216,18 +216,22 @@
 			min-width: 420px;
 		}
 
-		.settings__form label {
+		.settings__form label:not(:has(input[type='checkbox'])) {
+			display: grid;
+			grid-template-columns: 1fr 160px;
 			column-gap: 0.75rem;
 		}
 
-		.settings__form label > :last-child:not(input[type='checkbox']) {
-			flex: 1;
+		.settings__form input:not([type='checkbox']),
+		.settings__form textarea,
+		.settings__form select {
 			max-width: none;
 			width: 100%;
 		}
 
-		.settings__form label > :first-child {
-			flex-shrink: 0;
+		.settings__form fieldset:last-child {
+			display: flex;
+			justify-content: flex-end;
 		}
 	}
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -380,7 +380,7 @@
 </template>
 <svelte:window
 	onkeydown={(e) => {
-		if (e.key === 'Escape') settingsOpen = false;
+		if (settingsOpen && e.key === 'Escape') settingsOpen = false;
 	}}
 />
 <main>


### PR DESCRIPTION
## Summary

- Replaces the broken stacked mobile layout with a burger menu drawer (slide-in from right with backdrop)
- Fixes the settings panel height and content vertical alignment on desktop
- Adds a responsive breakpoint at 1024px: wider settings panel (420px), uniform and right-aligned form controls

## Changes

- **Mobile (≤ 480px)**: burger button, slide-in settings drawer, close button, backdrop overlay
- **Desktop**: `align-items: stretch` on main so the settings panel fills the full viewport height; content area vertically centered
- **Large screens (≥ 1024px)**: settings panel widens to 420px; form controls use `flex: 0 0 200px` for uniform width, right-aligned via `justify-content: space-between`; button right-aligned at bottom of form
- Unifies `input`, `textarea`, and `select` base widths to 100px (was 80px for select)

## Test plan

- [ ] Desktop: settings panel fills full height, "Hover me" button is vertically centered
- [ ] Desktop ≥ 1024px: all form controls are the same width and right-aligned
- [ ] Mobile: burger button appears, tapping it opens the settings drawer; backdrop click closes it; ✕ button closes it
- [ ] No regression on tooltip behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)