### PR TITLE
feat(tooltip): Reposition tooltip on resize/scroll instead of hiding it

### DIFF
--- a/src/lib/Tooltip.ts
+++ b/src/lib/Tooltip.ts
@@ -776,10 +776,15 @@ class Tooltip {
 
 	async #onWindowChange(e: Event) {
 		if (this.#open) return;
+		if (!this.#tooltip || !this.#tooltip.parentNode) return;
+
+		if (e.type === 'resize' || e.type === 'scroll') {
+			this.#positionTooltip();
+			return;
+		}
+
 		const ke = e as KeyboardEvent;
 		if (
-			this.#tooltip &&
-			this.#tooltip.parentNode &&
 			(e.type !== 'keydown' || ke.key === 'Escape' || ke.key === 'Esc') &&
 			(e.type !== 'touchstart' || !this.#target?.contains(e.target as Node))
 		) {

--- a/src/lib/__tests__/useTooltip.test.ts
+++ b/src/lib/__tests__/useTooltip.test.ts
@@ -131,7 +131,7 @@ describe('useTooltip', () => {
 			spy.mockRestore();
 		});
 
-		test('Removes tooltip on scroll inside a scrollable ancestor container', async () => {
+		test('Repositions tooltip on scroll inside a scrollable ancestor container', async () => {
 			const container = createElement({
 				tag: 'div',
 				attributes: { id: 'container' },
@@ -145,7 +145,7 @@ describe('useTooltip', () => {
 			expect(getElement('#content')).toBeInTheDocument();
 
 			await fireEvent.scroll(container);
-			expect(getElement('#content')).not.toBeInTheDocument();
+			expect(getElement('#content')).toBeInTheDocument();
 
 			await action.destroy();
 			action = null;
@@ -171,6 +171,24 @@ describe('useTooltip', () => {
 			await action.destroy();
 			action = null;
 			removeElement('#container');
+		});
+
+		test('Repositions tooltip on window resize', async () => {
+			action = createAction(target, options);
+			await _enter(target);
+			expect(getElement('#content')).toBeInTheDocument();
+
+			await fireEvent.resize(window);
+			expect(getElement('#content')).toBeInTheDocument();
+		});
+
+		test('Repositions tooltip on window scroll', async () => {
+			action = createAction(target, options);
+			await _enter(target);
+			expect(getElement('#content')).toBeInTheDocument();
+
+			await fireEvent.scroll(window);
+			expect(getElement('#content')).toBeInTheDocument();
 		});
 
 		test('Removes ancestor scroll listeners on destroy', async () => {

--- a/src/lib/__tests__/useTooltip.test.ts
+++ b/src/lib/__tests__/useTooltip.test.ts
@@ -144,8 +144,11 @@ describe('useTooltip', () => {
 			await _enter(target);
 			expect(getElement('#content')).toBeInTheDocument();
 
+			const spy = vi.spyOn(target, 'getBoundingClientRect');
 			await fireEvent.scroll(container);
 			expect(getElement('#content')).toBeInTheDocument();
+			expect(spy).toHaveBeenCalled();
+			spy.mockRestore();
 
 			await action.destroy();
 			action = null;
@@ -178,8 +181,11 @@ describe('useTooltip', () => {
 			await _enter(target);
 			expect(getElement('#content')).toBeInTheDocument();
 
+			const spy = vi.spyOn(target, 'getBoundingClientRect');
 			await fireEvent.resize(window);
 			expect(getElement('#content')).toBeInTheDocument();
+			expect(spy).toHaveBeenCalled();
+			spy.mockRestore();
 		});
 
 		test('Repositions tooltip on window scroll', async () => {
@@ -187,8 +193,11 @@ describe('useTooltip', () => {
 			await _enter(target);
 			expect(getElement('#content')).toBeInTheDocument();
 
+			const spy = vi.spyOn(target, 'getBoundingClientRect');
 			await fireEvent.scroll(window);
 			expect(getElement('#content')).toBeInTheDocument();
+			expect(spy).toHaveBeenCalled();
+			spy.mockRestore();
 		});
 
 		test('Removes ancestor scroll listeners on destroy', async () => {


### PR DESCRIPTION
## Summary

When the window is resized or scrolled, the tooltip was previously hidden, forcing the user to re-hover to see it again. This PR replaces that behaviour with a reposition call so the tooltip stays visible and tracks its trigger.

## Changes

- `src/lib/Tooltip.ts` — `#onWindowChange` now calls `#positionTooltip()` on `resize` and `scroll` events instead of removing the tooltip; `keydown` (Escape) and `touchstart` still dismiss it
- `src/lib/__tests__/useTooltip.test.ts` — updated existing scroll test to reflect new behaviour; added regression tests for `resize` and `scroll` on `window`

## Test plan

- [ ] Hover the trigger to show the tooltip, then resize the window → tooltip stays visible and repositions
- [ ] Hover the trigger, then scroll the page → tooltip stays visible and repositions
- [ ] Scroll inside a scrollable ancestor → tooltip stays visible and repositions
- [ ] Press Escape → tooltip still dismisses
- [ ] Touch outside (toggle mode) → tooltip still dismisses

Closes #140