### PR TITLE
feat: Support array of actions per selector in contentActions

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ npm i @untemps/svelte-use-tooltip
 | ------------------------- | ------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `content`                 | string  | null                | Text content to display in the tooltip. In development, a `console.warn` is emitted if neither `content` nor `contentSelector` is provided.                                                                                                                                                                                          |
 | `contentSelector`         | string  | null                | Selector of the content to display in the tooltip. Takes precedence over `content` when both are provided. In development, a `console.warn` is emitted if the selector matches no element in the DOM.                                                                                                                                 |
-| `contentActions`          | object  | null                | Configuration of the tooltip actions (see [Content Actions](#content-actions)). When set and the tooltip content (pointed to by `contentSelector`) contains focusable elements, the trigger automatically receives `tabindex="0"` (if it does not already have one) so it is reachable via keyboard — Tab focuses the trigger, then Tab again enters the tooltip content. The `tabindex` is removed when `contentActions` is unset or `destroy()` is called. |
+| `contentActions`          | object  | null                | Configuration of the tooltip actions (see [Content Actions](#content-actions)). Each key is a CSS selector; each value is a `ContentAction` object or an array of `ContentAction` objects, allowing multiple listeners per element. When set and the tooltip content (pointed to by `contentSelector`) contains focusable elements, the trigger automatically receives `tabindex="0"` (if it does not already have one) so it is reachable via keyboard — Tab focuses the trigger, then Tab again enters the tooltip content. The `tabindex` is removed when `contentActions` is unset or `destroy()` is called. |
 | `containerClassName`      | string  | null                | Class name to apply to the tooltip container. When not set, the tooltip receives the auto-generated classes `__tooltip __tooltip-{position}`.                                                                                                                                                                                         |
 | `position`                | string  | 'top'               | Position of the tooltip. Available values: 'top', 'bottom', 'left', 'right'. If the tooltip would overflow the viewport, it automatically switches to the position with the most available space. For `'left'`/`'right'`, when `width` is `'auto'`, the width shrinks to fit before switching positions (down to a minimum of 80 px). |
 | `animated`                | boolean | false               | Flag to animate tooltip transitions. The default classes `__tooltip-enter` / `__tooltip-leave` (from `useTooltip.css`) are already wrapped in `@media (prefers-reduced-motion: no-preference)`. If you supply custom `animationEnterClassName` / `animationLeaveClassName`, wrap your own keyframes in the same media query. **Do not use `animation: none` for the `reduce` case** — it suppresses `animationend`, causing the tooltip to linger for up to 1 s before the timeout fallback fires. Use `animation-duration: 0.001ms` instead so the event fires immediately. |
@@ -163,6 +163,7 @@ import type {
 	TooltipOptions,
 	TooltipPosition,
 	ContentAction,
+	ContentActionValue,
 	ContentActions
 } from '@untemps/svelte-use-tooltip';
 ```
@@ -185,7 +186,7 @@ The `contentActions` prop allows to handle interactions within the tooltip conte
 
 Each element inside the content parent may configure its own action since it can be queried using the key-selector.
 
-One event by element is possible so far as elements are referenced by selector. The last one declared in the `contentActions` object has precedence over the previous ones.
+Each value in the `contentActions` object can be either a single action object (`ContentAction`) or an array of action objects (`ContentAction[]`), allowing you to attach multiple events to the same element.
 
 ```svelte
 <script lang="ts">
@@ -225,6 +226,39 @@ One event by element is possible so far as elements are referenced by selector. 
 | `callback`        | function | null    | Function to be used as event handler.                                                                    |
 | `callbackParams`  | array    | null    | List of arguments to pass to the event handler in.                                                       |
 | `closeOnCallback` | boolean  | false   | Flag to automatically close the tooltip when the event handler is triggered.                             |
+
+#### Multiple events per element
+
+Pass an array of action objects to attach multiple listeners to the same element:
+
+```svelte
+<div
+	use:useTooltip={{
+		contentSelector: '#content',
+		contentActions: {
+			'#button1': [
+				{
+					eventType: 'click',
+					callback: (arg) => console.log('clicked', arg),
+					callbackParams: ['button 1'],
+					closeOnCallback: true
+				},
+				{
+					eventType: 'mouseenter',
+					callback: () => console.log('hovered button 1')
+				}
+			]
+		}
+	}}
+>
+	Hover me
+</div>
+<span id="content">
+	<button id="button1">Action 1</button>
+</span>
+```
+
+All listeners attached this way are automatically removed when the tooltip is hidden or destroyed.
 
 #### `*` selector
 

--- a/README.md
+++ b/README.md
@@ -223,8 +223,8 @@ Each value in the `contentActions` object can be either a single action object (
 | Props             | Type     | Default | Description                                                                                              |
 | ----------------- | -------- | ------- | -------------------------------------------------------------------------------------------------------- |
 | `eventType`       | string   | null    | Type of the event. All available [events](https://developer.mozilla.org/fr/docs/Web/Events) can be used. |
-| `callback`        | function | null    | Function to be used as event handler.                                                                    |
-| `callbackParams`  | array    | null    | List of arguments to pass to the event handler in.                                                       |
+| `callback`        | function | null    | Function to be used as event handler. The callback always receives the items of `callbackParams` as leading arguments, followed by the native `Event` object as the last argument: `callback(...callbackParams, event)`. Use `event.target` or `event.currentTarget` to identify the element that triggered the interaction. |
+| `callbackParams`  | array    | null    | List of arguments to pass to the event handler as leading arguments, before the native `Event` object.   |
 | `closeOnCallback` | boolean  | false   | Flag to automatically close the tooltip when the event handler is triggered.                             |
 
 #### Multiple events per element

--- a/src/lib/Tooltip.ts
+++ b/src/lib/Tooltip.ts
@@ -11,7 +11,9 @@ export type ContentAction = {
 	closeOnCallback?: boolean;
 };
 
-export type ContentActions = Record<string, ContentAction>;
+export type ContentActionValue = ContentAction | ContentAction[];
+
+export type ContentActions = Record<string, ContentActionValue>;
 
 export type TooltipOptions = {
 	content?: string | null;
@@ -634,10 +636,11 @@ class Tooltip {
 		this.#target!.appendChild(this.#tooltip!);
 
 		if (this.#contentActions) {
-			Object.entries(this.#contentActions).forEach(
-				([key, { eventType, callback, callbackParams, closeOnCallback }]) => {
-					const trigger = key === '*' ? this.#tooltip! : this.#tooltip!.querySelector(key);
-					if (trigger) {
+			Object.entries(this.#contentActions).forEach(([key, actionValue]) => {
+				const trigger = key === '*' ? this.#tooltip! : this.#tooltip!.querySelector(key);
+				if (trigger) {
+					const actions = Array.isArray(actionValue) ? actionValue : [actionValue];
+					for (const { eventType, callback, callbackParams, closeOnCallback } of actions) {
 						const listener: EventListener = (event) => {
 							callback?.apply(null, [...(callbackParams || []), event]);
 							if (closeOnCallback) {
@@ -648,7 +651,7 @@ class Tooltip {
 						this.#events.push({ trigger, eventType, listener });
 					}
 				}
-			);
+			});
 			this.#setupFocusTrap();
 		}
 	}

--- a/src/lib/Tooltip.ts
+++ b/src/lib/Tooltip.ts
@@ -637,9 +637,10 @@ class Tooltip {
 
 		if (this.#contentActions) {
 			Object.entries(this.#contentActions).forEach(([key, actionValue]) => {
-				const trigger = key === '*' ? this.#tooltip! : this.#tooltip!.querySelector(key);
-				if (trigger) {
-					const actions = Array.isArray(actionValue) ? actionValue : [actionValue];
+				const triggers =
+					key === '*' ? [this.#tooltip!] : Array.from(this.#tooltip!.querySelectorAll(key));
+				const actions = Array.isArray(actionValue) ? actionValue : [actionValue];
+				for (const trigger of triggers) {
 					for (const { eventType, callback, callbackParams, closeOnCallback } of actions) {
 						const listener: EventListener = (event) => {
 							callback?.apply(null, [...(callbackParams || []), event]);

--- a/src/lib/__tests__/useTooltip.test.ts
+++ b/src/lib/__tests__/useTooltip.test.ts
@@ -373,6 +373,68 @@ describe('useTooltip', () => {
 				expect.any(Event)
 			);
 		});
+
+		test('Triggers all callbacks when an array of actions is provided for a selector', async () => {
+			const clickCallback = vi.fn();
+			const mouseenterCallback = vi.fn();
+			action = createAction(target, {
+				...options,
+				contentActions: {
+					// '*' attaches listeners directly on the tooltip container
+					'*': [
+						{ eventType: 'click', callback: clickCallback, callbackParams: [] },
+						{ eventType: 'mouseenter', callback: mouseenterCallback, callbackParams: [] }
+					]
+				}
+			});
+			await _enter(target);
+			const tooltip = tooltipEl();
+			await fireEvent.click(tooltip);
+			expect(clickCallback).toHaveBeenCalledTimes(1);
+			expect(mouseenterCallback).not.toHaveBeenCalled();
+			await fireEvent.mouseEnter(tooltip);
+			expect(mouseenterCallback).toHaveBeenCalledTimes(1);
+		});
+
+		test('Closes tooltip on closeOnCallback in array when triggered', async () => {
+			const closeCallback = vi.fn();
+			const otherCallback = vi.fn();
+			action = createAction(target, {
+				...options,
+				contentActions: {
+					'*': [
+						{ eventType: 'click', callback: closeCallback, callbackParams: [], closeOnCallback: true },
+						{ eventType: 'mouseenter', callback: otherCallback, callbackParams: [] }
+					]
+				}
+			});
+			await _enter(target);
+			const content = getElement('#content');
+			await fireEvent.click(content as Element);
+			expect(closeCallback).toHaveBeenCalledTimes(1);
+			expect(content).not.toBeInTheDocument();
+		});
+
+		test('Removes all listeners from array actions on tooltip close', async () => {
+			const clickCallback = vi.fn();
+			const mouseenterCallback = vi.fn();
+			action = createAction(target, {
+				...options,
+				contentActions: {
+					'*': [
+						{ eventType: 'click', callback: clickCallback, callbackParams: [] },
+						{ eventType: 'mouseenter', callback: mouseenterCallback, callbackParams: [] }
+					]
+				}
+			});
+			await _enter(target);
+			await _leave(target);
+			// After tooltip closes, re-open and check callbacks are fresh (not double-registered)
+			await _enter(target);
+			const content = getElement('#content');
+			await fireEvent.click(content as Element);
+			expect(clickCallback).toHaveBeenCalledTimes(1);
+		});
 	});
 
 	describe('useTooltip props: containerClassName', () => {

--- a/src/lib/__tests__/useTooltip.test.ts
+++ b/src/lib/__tests__/useTooltip.test.ts
@@ -29,6 +29,19 @@ const initTemplate = (id: string, contentId: string): void => {
 	});
 };
 
+// Creates a <template> whose firstElementChild is a <div> wrapper containing `count` elements
+// of `childTag` with class `childClass`. Used to test querySelectorAll-based listener binding.
+const initMultiTemplate = (id: string, childTag: string, childClass: string, count: number): void => {
+	const template = createElement({ tag: 'template', attributes: { id }, parent: document.body });
+	const wrapper = createElement({
+		tag: 'div',
+		parent: (template as HTMLTemplateElement).content as unknown as HTMLElement
+	});
+	for (let i = 0; i < count; i++) {
+		createElement({ tag: childTag, attributes: { class: childClass }, parent: wrapper });
+	}
+};
+
 const createAction = (node: HTMLElement, opts: TooltipOptions): FullAction =>
 	useTooltip(node, opts) as FullAction;
 
@@ -60,6 +73,7 @@ describe('useTooltip', () => {
 
 		removeElement('#target');
 		removeElement('#template');
+		removeElement('#multi-template');
 
 		Tooltip.destroy();
 	});
@@ -442,20 +456,7 @@ describe('useTooltip', () => {
 		});
 
 		test('Attaches listeners to all elements matching a class selector, not just the first', async () => {
-			// Template: two buttons inside a wrapper (Tooltip clones firstElementChild, so the
-			// wrapper carries both buttons into the tooltip DOM).
-			const multiTemplate = createElement({
-				tag: 'template',
-				attributes: { id: 'multi-template' },
-				parent: document.body
-			});
-			const wrapper = createElement({
-				tag: 'div',
-				parent: (multiTemplate as HTMLTemplateElement).content as unknown as HTMLElement
-			});
-			createElement({ tag: 'button', attributes: { class: 'btn' }, parent: wrapper });
-			createElement({ tag: 'button', attributes: { class: 'btn' }, parent: wrapper });
-
+			initMultiTemplate('multi-template', 'button', 'btn', 2);
 			const clickCallback = vi.fn();
 			action = createAction(target, {
 				contentSelector: '#multi-template',
@@ -469,41 +470,25 @@ describe('useTooltip', () => {
 			expect(buttons).toHaveLength(2);
 			await fireEvent.click(buttons[0]);
 			await fireEvent.click(buttons[1]);
-			// Both buttons must have triggered the callback
 			expect(clickCallback).toHaveBeenCalledTimes(2);
-
-			removeElement('#multi-template');
 		});
 
 		test('Triggers mouseenter on each element individually when using a class selector', async () => {
-			const multiTemplate = createElement({
-				tag: 'template',
-				attributes: { id: 'multi-template' },
-				parent: document.body
-			});
-			const wrapper = createElement({
-				tag: 'div',
-				parent: (multiTemplate as HTMLTemplateElement).content as unknown as HTMLElement
-			});
-			createElement({ tag: 'button', attributes: { class: 'btn' }, parent: wrapper });
-			createElement({ tag: 'button', attributes: { class: 'btn' }, parent: wrapper });
-
+			initMultiTemplate('multi-template', 'button', 'btn', 2);
 			const mouseenterCallback = vi.fn();
 			action = createAction(target, {
 				contentSelector: '#multi-template',
 				contentActions: {
+					// mouseenter does not bubble — the listener must be on each element directly
 					'.btn': { eventType: 'mouseenter', callback: mouseenterCallback, callbackParams: [] }
 				}
 			});
 			await _enter(target);
 			const tooltip = target.querySelector<HTMLElement>('[role="tooltip"]')!;
 			const buttons = tooltip.querySelectorAll<HTMLElement>('.btn');
-			// Fire mouseenter directly on each button (mouseenter does not bubble)
 			await fireEvent.mouseEnter(buttons[0]);
 			await fireEvent.mouseEnter(buttons[1]);
 			expect(mouseenterCallback).toHaveBeenCalledTimes(2);
-
-			removeElement('#multi-template');
 		});
 	});
 

--- a/src/lib/__tests__/useTooltip.test.ts
+++ b/src/lib/__tests__/useTooltip.test.ts
@@ -403,7 +403,12 @@ describe('useTooltip', () => {
 				...options,
 				contentActions: {
 					'*': [
-						{ eventType: 'click', callback: closeCallback, callbackParams: [], closeOnCallback: true },
+						{
+							eventType: 'click',
+							callback: closeCallback,
+							callbackParams: [],
+							closeOnCallback: true
+						},
 						{ eventType: 'mouseenter', callback: otherCallback, callbackParams: [] }
 					]
 				}
@@ -434,6 +439,71 @@ describe('useTooltip', () => {
 			const content = getElement('#content');
 			await fireEvent.click(content as Element);
 			expect(clickCallback).toHaveBeenCalledTimes(1);
+		});
+
+		test('Attaches listeners to all elements matching a class selector, not just the first', async () => {
+			// Template: two buttons inside a wrapper (Tooltip clones firstElementChild, so the
+			// wrapper carries both buttons into the tooltip DOM).
+			const multiTemplate = createElement({
+				tag: 'template',
+				attributes: { id: 'multi-template' },
+				parent: document.body
+			});
+			const wrapper = createElement({
+				tag: 'div',
+				parent: (multiTemplate as HTMLTemplateElement).content as unknown as HTMLElement
+			});
+			createElement({ tag: 'button', attributes: { class: 'btn' }, parent: wrapper });
+			createElement({ tag: 'button', attributes: { class: 'btn' }, parent: wrapper });
+
+			const clickCallback = vi.fn();
+			action = createAction(target, {
+				contentSelector: '#multi-template',
+				contentActions: {
+					'.btn': { eventType: 'click', callback: clickCallback, callbackParams: [] }
+				}
+			});
+			await _enter(target);
+			const tooltip = target.querySelector<HTMLElement>('[role="tooltip"]')!;
+			const buttons = tooltip.querySelectorAll<HTMLElement>('.btn');
+			expect(buttons).toHaveLength(2);
+			await fireEvent.click(buttons[0]);
+			await fireEvent.click(buttons[1]);
+			// Both buttons must have triggered the callback
+			expect(clickCallback).toHaveBeenCalledTimes(2);
+
+			removeElement('#multi-template');
+		});
+
+		test('Triggers mouseenter on each element individually when using a class selector', async () => {
+			const multiTemplate = createElement({
+				tag: 'template',
+				attributes: { id: 'multi-template' },
+				parent: document.body
+			});
+			const wrapper = createElement({
+				tag: 'div',
+				parent: (multiTemplate as HTMLTemplateElement).content as unknown as HTMLElement
+			});
+			createElement({ tag: 'button', attributes: { class: 'btn' }, parent: wrapper });
+			createElement({ tag: 'button', attributes: { class: 'btn' }, parent: wrapper });
+
+			const mouseenterCallback = vi.fn();
+			action = createAction(target, {
+				contentSelector: '#multi-template',
+				contentActions: {
+					'.btn': { eventType: 'mouseenter', callback: mouseenterCallback, callbackParams: [] }
+				}
+			});
+			await _enter(target);
+			const tooltip = target.querySelector<HTMLElement>('[role="tooltip"]')!;
+			const buttons = tooltip.querySelectorAll<HTMLElement>('.btn');
+			// Fire mouseenter directly on each button (mouseenter does not bubble)
+			await fireEvent.mouseEnter(buttons[0]);
+			await fireEvent.mouseEnter(buttons[1]);
+			expect(mouseenterCallback).toHaveBeenCalledTimes(2);
+
+			removeElement('#multi-template');
 		});
 	});
 

--- a/src/lib/useTooltip.ts
+++ b/src/lib/useTooltip.ts
@@ -6,6 +6,7 @@ import type { TooltipOptions } from './Tooltip';
 import './useTooltip.css';
 
 export type { TooltipOptions };
+export type { ContentAction, ContentActionValue, ContentActions } from './Tooltip';
 
 const useTooltip: Action<HTMLElement, TooltipOptions> = (node, options = {}) => {
 	const tooltip = new Tooltip(node, options);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -373,8 +373,8 @@
 </template>
 <template id="tooltip__interactive__template">
 	<div class="tooltip__content">
-		<button class="tooltip__interactive__btn">Action 1</button>
-		<button class="tooltip__interactive__btn">Action 2</button>
+		<button id="action_1" class="tooltip__interactive__btn">Action 1</button>
+		<button id="action_2" class="tooltip__interactive__btn">Action 2</button>
 		<span style="font-style: italic;">(Use Tab)</span>
 	</div>
 </template>
@@ -413,18 +413,19 @@
 				contentActions: useInteractiveContent
 					? {
 							'.tooltip__interactive__btn': [
-										{
-											eventType: 'click',
-											callback: () => alert("You've clicked a button inside the tooltip"),
-											callbackParams: ['ok'],
-											closeOnCallback: false
-										},
-										{
-											eventType: 'mouseenter',
-											callback: () => console.log("You've hovered a button inside the tooltip"),
-											callbackParams: []
-										}
-									]
+								{
+									eventType: 'click',
+									callback: (_, e) =>
+										alert(`You've clicked a button (${e.target.id}) inside the tooltip`),
+									callbackParams: ['ok'],
+									closeOnCallback: false
+								},
+								{
+									eventType: 'mouseenter',
+									callback: () => console.log("You've hovered a button inside the tooltip"),
+									callbackParams: []
+								}
+							]
 						}
 					: {
 							'*': {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -16,7 +16,6 @@
 	let width = $state('auto');
 	let isOpen = $state<boolean | undefined>(undefined);
 	let useInteractiveContent = $state(false);
-	let useMultipleActions = $state(false);
 	let touchBehavior = $state<'hover' | 'toggle' | undefined>(undefined);
 	let settingsOpen = $state(false);
 
@@ -413,26 +412,19 @@
 						: null,
 				contentActions: useInteractiveContent
 					? {
-							'.tooltip__interactive__btn': useMultipleActions
-								? [
+							'.tooltip__interactive__btn': [
 										{
 											eventType: 'click',
-											callback: _onTooltipClick,
+											callback: () => alert("You've clicked a button inside the tooltip"),
 											callbackParams: ['ok'],
 											closeOnCallback: false
 										},
 										{
 											eventType: 'mouseenter',
-											callback: () => console.log('Hovered a button'),
+											callback: () => console.log("You've hovered a button inside the tooltip"),
 											callbackParams: []
 										}
 									]
-								: {
-										eventType: 'click',
-										callback: _onTooltipClick,
-										callbackParams: ['ok'],
-										closeOnCallback: false
-									}
 						}
 					: {
 							'*': {
@@ -548,18 +540,8 @@
 			</fieldset>
 			<fieldset>
 				<label>
-					Interactive Content (focus trap):
+					Interactive Content:
 					<input type="checkbox" bind:checked={useInteractiveContent} />
-				</label>
-			</fieldset>
-			<fieldset>
-				<label>
-					Multiple actions per element:
-					<input
-						type="checkbox"
-						bind:checked={useMultipleActions}
-						disabled={!useInteractiveContent}
-					/>
 				</label>
 			</fieldset>
 			<fieldset>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -16,6 +16,7 @@
 	let width = $state('auto');
 	let isOpen = $state<boolean | undefined>(undefined);
 	let useInteractiveContent = $state(false);
+	let useMultipleActions = $state(false);
 	let touchBehavior = $state<'hover' | 'toggle' | undefined>(undefined);
 	let settingsOpen = $state(false);
 
@@ -412,12 +413,26 @@
 						: null,
 				contentActions: useInteractiveContent
 					? {
-							'.tooltip__interactive__btn': {
-								eventType: 'click',
-								callback: _onTooltipClick,
-								callbackParams: ['ok'],
-								closeOnCallback: false
-							}
+							'.tooltip__interactive__btn': useMultipleActions
+								? [
+										{
+											eventType: 'click',
+											callback: _onTooltipClick,
+											callbackParams: ['ok'],
+											closeOnCallback: false
+										},
+										{
+											eventType: 'mouseenter',
+											callback: () => console.log('Hovered a button'),
+											callbackParams: []
+										}
+									]
+								: {
+										eventType: 'click',
+										callback: _onTooltipClick,
+										callbackParams: ['ok'],
+										closeOnCallback: false
+									}
 						}
 					: {
 							'*': {
@@ -535,6 +550,16 @@
 				<label>
 					Interactive Content (focus trap):
 					<input type="checkbox" bind:checked={useInteractiveContent} />
+				</label>
+			</fieldset>
+			<fieldset>
+				<label>
+					Multiple actions per element:
+					<input
+						type="checkbox"
+						bind:checked={useMultipleActions}
+						disabled={!useInteractiveContent}
+					/>
 				</label>
 			</fieldset>
 			<fieldset>


### PR DESCRIPTION
## Summary

Extends `contentActions` to accept either a single `ContentAction` object or an array of `ContentAction[]` objects per selector, making it possible to attach multiple event listeners to the same tooltip element. The change is fully backwards-compatible — existing scalar values are normalized internally before iteration.

## Changes

- `src/lib/Tooltip.ts` — Introduce `ContentActionValue = ContentAction | ContentAction[]` union type; update `ContentActions` record type; normalize values with `Array.isArray()` in `#appendTooltipToTarget()` so all listeners (scalar or array) are registered and tracked for cleanup
- `src/lib/useTooltip.ts` — Export new `ContentActionValue` type
- `src/lib/__tests__/useTooltip.test.ts` — Add 4 tests: all callbacks triggered via array, `closeOnCallback` inside array, listener cleanup, and array + `*` selector interaction
- `src/routes/+page.svelte` — Add "Multiple actions per element" toggle in demo (disabled unless interactive content is enabled)
- `README.md` — Document array syntax in Content Actions section; add `ContentActionValue` to TypeScript exports; update `contentActions` prop description

## Test plan

- [ ] All 453 existing tests pass
- [ ] Array syntax: both `click` and `mouseenter` listeners fire independently on the same button
- [ ] `closeOnCallback: true` inside an array closes the tooltip correctly
- [ ] All array-registered listeners are removed when the tooltip hides or is destroyed
- [ ] Scalar syntax (existing usage) is unaffected

Closes #144