### PR TITLE
fix(tooltip): Treat disabled:undefined as no-op in update() to prevent accidental re-enable

### DIFF
--- a/src/lib/Tooltip.ts
+++ b/src/lib/Tooltip.ts
@@ -227,15 +227,15 @@ class Tooltip {
 			hasContainerClassNameChanged:
 				containerClassName !== undefined && containerClassName !== this.#containerClassName,
 			hasWidthChanged: width !== undefined && width !== this.#width,
-			hasToDisableTarget: !!disabled && Boolean(this.#boundEnterHandler),
-			hasToEnableTarget: !disabled && !Boolean(this.#boundEnterHandler),
+			hasToDisableTarget: disabled === true && Boolean(this.#boundEnterHandler),
+			hasToEnableTarget: disabled === false && !Boolean(this.#boundEnterHandler),
 			hasTouchBehaviorChanged: touchBehavior !== undefined && touchBehavior !== this.#touchBehavior,
 			hasShowHideConfigChanged:
 				(showOn !== undefined && showOn.join(',') !== this.#showOn.join(',')) ||
 				(hideOn !== undefined && hideOn.join(',') !== this.#hideOn.join(',')),
 			// Re-show when open:true is passed after a structure rebuild (tooltip removed from DOM),
-			// or when the tooltip is not yet visible. Guard with !disabled so open+disabled is a no-op.
-			hasToShow: open === true && !disabled && (!isCurrentlyShown || hasStructureChanged),
+			// or when the tooltip is not yet visible. Skip when disabled is explicitly true.
+			hasToShow: open === true && disabled !== true && (!isCurrentlyShown || hasStructureChanged),
 			// Skip explicit hide when structure already removed the tooltip from the DOM.
 			hasToHide: open === false && isCurrentlyShown && !hasStructureChanged,
 			hasInteractivityChanged: (() => {

--- a/src/lib/__tests__/useTooltip.test.ts
+++ b/src/lib/__tests__/useTooltip.test.ts
@@ -659,6 +659,21 @@ describe('useTooltip', () => {
 			action.update({ disabled: true });
 			expect(getElement('#content')).not.toBeInTheDocument();
 		});
+
+		test('Partial update without disabled keeps a disabled tooltip disabled', async () => {
+			action = createAction(target, { ...options, disabled: true });
+			// update without disabled — must not re-enable
+			action.update({ contentSelector: '#template' });
+			await _enter(target);
+			expect(getElement('#content')).not.toBeInTheDocument();
+		});
+
+		test('Partial update without disabled keeps an enabled tooltip enabled', async () => {
+			action = createAction(target, options);
+			action.update({ contentSelector: '#template' });
+			await _enter(target);
+			expect(getElement('#content')).toBeInTheDocument();
+		});
 	});
 
 	describe('useTooltip props: position', () => {


### PR DESCRIPTION
## Summary

When a disabled tooltip received a partial `update()` call that omitted the `disabled` prop, it was silently re-enabled. The root cause was `hasToEnableTarget: !disabled && ...` — `!undefined` evaluates to `true`, triggering `#enable()`. Symmetrically, `hasToDisableTarget` used `!!disabled` which is also truthy for non-boolean values. Both guards are replaced with strict equality checks so that `disabled: undefined` (omitted) is a no-op, matching the partial update semantics introduced in #189.

The `hasToShow` guard is also corrected from `!disabled` to `disabled !== true` so that `open: true` without a `disabled` prop correctly shows an enabled tooltip.

## Changes

- `src/lib/Tooltip.ts` — `#detectChanges`: `!!disabled` → `disabled === true`, `!disabled` → `disabled === false`, `!disabled` in `hasToShow` → `disabled !== true`
- `src/lib/__tests__/useTooltip.test.ts` — 2 new regression tests: partial update without `disabled` keeps a disabled tooltip disabled; partial update without `disabled` keeps an enabled tooltip enabled

## Test plan

- [ ] Disabled tooltip stays disabled after `update({ contentSelector: '#template' })` (no `disabled`)
- [ ] Disabled tooltip re-enables after `update({ disabled: false })`
- [ ] Enabled tooltip disables after `update({ disabled: true })`
- [ ] `update({ open: true })` without `disabled` still shows an enabled tooltip
- [ ] Run `yarn test:ci` — all 500 tests pass

Closes #183