### PR TITLE
fix(tooltip): Apply showOn/hideOn update in all disabled-transition branches

### DIFF
--- a/src/lib/Tooltip.ts
+++ b/src/lib/Tooltip.ts
@@ -329,8 +329,15 @@ class Tooltip {
 			if (this.#tooltip?.parentNode) {
 				this.#removeTooltipFromTarget();
 			}
+			// #disable() uses the OLD #showOn/#hideOn to remove the correct listeners.
 			this.#disable();
+			// Update after disable so the new values are ready for the next #enable().
+			if (options.showOn !== undefined) this.#showOn = options.showOn;
+			if (options.hideOn !== undefined) this.#hideOn = options.hideOn;
 		} else if (hasToEnableTarget) {
+			// Update before #enable() so the new listeners are registered with the new config.
+			if (options.showOn !== undefined) this.#showOn = options.showOn;
+			if (options.hideOn !== undefined) this.#hideOn = options.hideOn;
 			this.#enable();
 		} else if (hasTouchBehaviorChanged || hasShowHideConfigChanged) {
 			// #disable() uses the OLD #showOn/#hideOn to remove the correct listeners.

--- a/src/lib/__tests__/useTooltip.test.ts
+++ b/src/lib/__tests__/useTooltip.test.ts
@@ -2228,10 +2228,8 @@ describe('useTooltip', () => {
 			action.update({ ...options, disabled: true, showOn: ['click'] });
 			// Re-enable without changing showOn — new value must have been stored
 			action.update({ ...options, disabled: false });
-			// mouseenter should NOT show (new showOn is click-only)
 			await _enter(target);
 			expect(getElement('#content')).not.toBeInTheDocument();
-			// click SHOULD show
 			await fireEvent.click(target);
 			await standby(1);
 			expect(getElement('#content')).toBeInTheDocument();
@@ -2242,10 +2240,8 @@ describe('useTooltip', () => {
 			action = createAction(target, { ...options, disabled: true });
 			// Re-enable and switch to click trigger at the same time
 			action.update({ ...options, disabled: false, showOn: ['click'] });
-			// mouseenter should NOT show (new showOn is click-only)
 			await _enter(target);
 			expect(getElement('#content')).not.toBeInTheDocument();
-			// click SHOULD show
 			await fireEvent.click(target);
 			await standby(1);
 			expect(getElement('#content')).toBeInTheDocument();

--- a/src/lib/__tests__/useTooltip.test.ts
+++ b/src/lib/__tests__/useTooltip.test.ts
@@ -2220,5 +2220,35 @@ describe('useTooltip', () => {
 			await standby(1);
 			expect(getElement('#content')).toBeInTheDocument();
 		});
+
+		test('Applies new showOn when disabled and showOn change simultaneously', async () => {
+			// Start enabled with default mouseenter trigger
+			action = createAction(target, options);
+			// Disable and switch to click trigger at the same time
+			action.update({ ...options, disabled: true, showOn: ['click'] });
+			// Re-enable without changing showOn — new value must have been stored
+			action.update({ ...options, disabled: false });
+			// mouseenter should NOT show (new showOn is click-only)
+			await _enter(target);
+			expect(getElement('#content')).not.toBeInTheDocument();
+			// click SHOULD show
+			await fireEvent.click(target);
+			await standby(1);
+			expect(getElement('#content')).toBeInTheDocument();
+		});
+
+		test('Applies new showOn when re-enabling and showOn change simultaneously', async () => {
+			// Start disabled
+			action = createAction(target, { ...options, disabled: true });
+			// Re-enable and switch to click trigger at the same time
+			action.update({ ...options, disabled: false, showOn: ['click'] });
+			// mouseenter should NOT show (new showOn is click-only)
+			await _enter(target);
+			expect(getElement('#content')).not.toBeInTheDocument();
+			// click SHOULD show
+			await fireEvent.click(target);
+			await standby(1);
+			expect(getElement('#content')).toBeInTheDocument();
+		});
 	});
 });


### PR DESCRIPTION
## Summary

When `showOn` or `hideOn` was changed at the same time as a `disabled` state transition, the new values were silently discarded. The `hasToDisableTarget` and `hasToEnableTarget` branches in `#applyChanges` never updated `#showOn`/`#hideOn` — only the `hasTouchBehaviorChanged || hasShowHideConfigChanged` branch did. The fix applies the update in all three branches while preserving the ordering constraint: `#disable()` reads OLD values to remove the correct listeners, then the fields are updated, then `#enable()` reads NEW values.

## Changes

- `src/lib/Tooltip.ts` — `#applyChanges`: update `#showOn`/`#hideOn` after `#disable()` in the `hasToDisableTarget` branch; update before `#enable()` in the `hasToEnableTarget` branch
- `src/lib/__tests__/useTooltip.test.ts` — 2 regression tests covering both affected paths

## Test plan

- [ ] `update({ disabled: true, showOn: ['click'] })` — tooltip is disabled and `showOn: ['click']` is stored; when re-enabled, mouseenter no longer triggers the tooltip but click does
- [ ] `update({ disabled: false, showOn: ['click'] })` — tooltip is re-enabled with `showOn: ['click']`; mouseenter no longer triggers but click does
- [ ] Existing `showOn`/`hideOn` tests pass without regression
- [ ] Run `yarn test:ci` — all 534 tests pass

Closes #184