### PR TITLE
fix(tooltip): Fire onLeave when Escape key closes the tooltip

### DIFF
--- a/src/lib/Tooltip.ts
+++ b/src/lib/Tooltip.ts
@@ -954,6 +954,7 @@ class Tooltip {
 			(e.type !== 'touchstart' || !this.#target?.contains(e.target as Node))
 		) {
 			await this.#removeTooltipFromTarget();
+			this.#onLeave?.();
 		}
 	}
 

--- a/src/lib/__tests__/useTooltip.test.ts
+++ b/src/lib/__tests__/useTooltip.test.ts
@@ -1103,6 +1103,26 @@ describe('useTooltip', () => {
 		});
 	});
 
+	describe('useTooltip props: onLeave', () => {
+		test('Triggers callback when leaving tooltip', async () => {
+			const onLeave = vi.fn(() => 0);
+			action = createAction(target, { ...options, onLeave });
+			await _enter(target);
+			await _leave(target);
+			await standby(0);
+			expect(onLeave).toHaveBeenCalled();
+		});
+
+		test('Triggers callback when Escape key closes the tooltip', async () => {
+			const onLeave = vi.fn(() => 0);
+			action = createAction(target, { ...options, onLeave });
+			await _enter(target);
+			await _keyDown(target);
+			await standby(0);
+			expect(onLeave).toHaveBeenCalled();
+		});
+	});
+
 	describe('useTooltip props: leaveDelay', () => {
 		test('Delays tooltip disappearance', async () => {
 			action = createAction(target, {


### PR DESCRIPTION
## Summary

`onLeave` was never called when the user closed the tooltip by pressing Escape. Every other close path (mouse leave, touch toggle, programmatic `open: false`) chains `this.#onLeave?.()` after `#removeTooltipFromTarget()`, but `#onWindowChange` — which handles the Escape key — did not. The fix adds the missing call, making all close paths consistent.

## Changes

- `src/lib/Tooltip.ts` — `#onWindowChange`: call `this.#onLeave?.()` after `await this.#removeTooltipFromTarget()`
- `src/lib/__tests__/useTooltip.test.ts` — new `onLeave` describe block with a general mouseleave test and a regression test for the Escape key path

## Test plan

- [ ] Show tooltip, press Escape — `onLeave` callback is invoked
- [ ] Show tooltip, move mouse away — `onLeave` callback is still invoked (no regression)
- [ ] Demo page: button label updates correctly when tooltip is dismissed with Escape
- [ ] Run `yarn test:ci` — all 540 tests pass

Closes #185