### PR TITLE
fix(tooltip): Normalize offset before change detection to avoid spurious rebuild

### DIFF
--- a/src/lib/Tooltip.ts
+++ b/src/lib/Tooltip.ts
@@ -220,7 +220,7 @@ class Tooltip {
 		const hasStructureChanged =
 			hasContentChanged ||
 			(position !== undefined && position !== this.#position) ||
-			(offset !== undefined && offset !== this.#offset);
+			(offset !== undefined && Math.max(offset, 5) !== this.#offset);
 		const isCurrentlyShown = !!this.#tooltip?.parentNode;
 		return {
 			hasStructureChanged,

--- a/src/lib/__tests__/useTooltip.test.ts
+++ b/src/lib/__tests__/useTooltip.test.ts
@@ -596,6 +596,16 @@ describe('useTooltip', () => {
 			await standby(1);
 			expect(target.querySelector('[role="tooltip"]')).not.toBeInTheDocument();
 		});
+
+		test('Below-minimum offset does not trigger a rebuild on repeated updates', async () => {
+			action = createAction(target, { content: 'Hello', offset: 3 });
+			await _enter(target);
+			const tooltipBefore = target.querySelector('[role="tooltip"]');
+			// Second update with the same below-minimum value — effective offset unchanged (clamped to 5)
+			action.update({ content: 'Hello', offset: 3 });
+			const tooltipAfter = target.querySelector('[role="tooltip"]');
+			expect(tooltipAfter).toBe(tooltipBefore);
+		});
 	});
 
 	describe('useTooltip props: containerClassName', () => {


### PR DESCRIPTION
## Summary

When `offset` was set below the enforced minimum of 5, every `update()` call triggered a full tooltip rebuild even when nothing had actually changed. The root cause: `#detectChanges` compared the raw incoming `offset` against the already-normalized `this.#offset` (clamped to 5 by `#applyState`), so `3 !== 5` always evaluated to `true`, setting `hasStructureChanged = true`. The fix applies the same `Math.max(offset, 5)` clamp in `#detectChanges` before the comparison.

## Changes

- `src/lib/Tooltip.ts` — `#detectChanges`: `offset !== this.#offset` → `Math.max(offset, 5) !== this.#offset`
- `src/lib/__tests__/useTooltip.test.ts` — 1 regression test: two consecutive updates with `offset: 3` produce the same tooltip DOM node (no rebuild)

## Test plan

- [ ] Two updates with `offset: 3` → tooltip DOM element is the same reference (no rebuild)
- [ ] Update from `offset: 3` to `offset: 8` → structure rebuilds as expected (distinct offset)
- [ ] Run `yarn test:ci` — all 543 tests pass

Closes #186