### PR TITLE
fix(tooltip): Clear observer before structure rebuild to prevent duplicate content

### DIFF
--- a/src/lib/Tooltip.ts
+++ b/src/lib/Tooltip.ts
@@ -311,6 +311,9 @@ class Tooltip {
 	) {
 		if (hasStructureChanged) {
 			this.#removeTooltipFromTarget(true);
+			// Cancel any pending contentSelector observer before re-registering a new one,
+			// otherwise both resolve when the template appears and content is appended twice.
+			this.#observer?.clear();
 			this.#createTooltip();
 			// Re-evaluate tabindex: the template may now have or lack focusable elements.
 			this.#syncTabIndex();

--- a/src/lib/__tests__/useTooltip.test.ts
+++ b/src/lib/__tests__/useTooltip.test.ts
@@ -295,6 +295,23 @@ describe('useTooltip', () => {
 			await _enter(target);
 			expect(getElement('#content')).not.toBeInTheDocument();
 		});
+
+		test('Does not duplicate content when structure rebuilds while contentSelector observer is pending', async () => {
+			// Remove template so the observer waits for it to appear dynamically
+			removeElement('#template');
+			action = createAction(target, { contentSelector: '#template' });
+
+			// Trigger a structure rebuild before the template appears
+			action.update({ contentSelector: '#template', position: 'bottom' });
+
+			// Now add the template — only the observer registered after the rebuild should fire
+			initTemplate('template', 'content');
+			await standby(10);
+
+			await _enter(target);
+			const tooltipEl = target.querySelector('[role="tooltip"]')!;
+			expect(tooltipEl.querySelectorAll('#content')).toHaveLength(1);
+		});
 	});
 
 	describe('useTooltip props: content', () => {


### PR DESCRIPTION
## Summary

On a structure rebuild, `#applyChanges` called `#createTooltip()` without first cancelling the pending `observer.wait()` registered by the previous `#createTooltip()`. If the `contentSelector` template was dynamically added to the DOM after the rebuild, both observers resolved and appended the content twice. The fix adds a single `this.#observer?.clear()` call immediately before `#createTooltip()` in the `hasStructureChanged` branch.

This only affects the edge case where `contentSelector` points to a template not yet in the DOM when the rebuild occurs (the `DOMObserver.ADD` path). Statically declared `<template>` elements are unaffected — their observer resolves synchronously on `EXIST` before any rebuild can occur.

## Changes

- `src/lib/Tooltip.ts` — `#applyChanges`: call `this.#observer?.clear()` before `#createTooltip()` when `hasStructureChanged` is true
- `src/lib/__tests__/useTooltip.test.ts` — 1 regression test: structure rebuild while contentSelector observer is pending → content appears exactly once after the template is dynamically added

## Test plan

- [ ] Structure rebuild with a pending contentSelector observer → tooltip content appears exactly once (not duplicated)
- [ ] Normal static template usage still works (no regression)
- [ ] Run `yarn test:ci` — all 546 tests pass

Closes #187