### PR TITLE
fix: Add types condition to exports map

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
 		"access": "public"
 	},
 	"svelte": "./dist/index.js",
+	"types": "./dist/index.d.ts",
 	"type": "module",
 	"files": [
 		"dist",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
 	],
 	"exports": {
 		".": {
+			"types": "./dist/index.d.ts",
 			"svelte": "./dist/index.js"
 		}
 	},


### PR DESCRIPTION
## Summary
The `exports` field in `package.json` was missing a `"types"` condition, making `dist/index.d.ts` unreachable for TypeScript consumers using `moduleResolution: "node16"`, `"nodenext"`, or `"bundler"`. This adds the missing entry as the first key under `exports["."]` so type resolution works out of the box.

## Changes
- `package.json` — add `"types": "./dist/index.d.ts"` to `exports["."]`

## Test plan
- [ ] Install the package in a TypeScript project with `moduleResolution: "bundler"` or `"node16"` and verify `useTooltip` resolves with its proper types (no `any`)
- [ ] Verify `publint` still reports no issues (`yarn build` includes a `publint` check)
- [ ] Confirm all 364 existing tests still pass (`yarn test:ci`)

Closes #197