### PR TITLE
fix: Add default condition to exports map

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
 	"exports": {
 		".": {
 			"types": "./dist/index.d.ts",
-			"svelte": "./dist/index.js"
+			"svelte": "./dist/index.js",
+			"default": "./dist/index.js"
 		}
 	},
 	"peerDependencies": {


### PR DESCRIPTION
## Summary
The `exports["."]` map was missing a `"default"` condition, causing bundlers without Svelte-condition support (plain Rollup, esbuild, webpack) to fail resolving the package entry point. Adding `"default"` as the last condition provides a catch-all fallback for these toolchains.

## Changes
- `package.json` — add `"default": "./dist/index.js"` as the last entry in `exports["."]`

## Test plan
- [ ] Verify the package resolves correctly in a plain Rollup or esbuild setup (no Svelte plugin)
- [ ] Confirm `publint` still reports no issues (`yarn build` includes the check)
- [ ] Confirm all 364 existing tests still pass (`yarn test:ci`)

Closes #210