### PR TITLE
fix: Remove async-executor antipattern in vitest.setup.ts

### DIFF
--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -16,73 +16,53 @@ declare global {
 	function _touchCancel(trigger: Element): Promise<void>;
 }
 
-global._enter = async (trigger: Element) =>
-	new Promise<void>(async (resolve) => {
-		await fireEvent.mouseOver(trigger); // fireEvent.mouseEnter only works if mouseOver is triggered before
-		await fireEvent.mouseEnter(trigger);
-		await standby(1);
-		resolve();
-	});
+global._enter = async (trigger: Element) => {
+	await fireEvent.mouseOver(trigger); // fireEvent.mouseEnter only works if mouseOver is triggered before
+	await fireEvent.mouseEnter(trigger);
+	await standby(1);
+};
 
-global._leave = async (trigger: Element) =>
-	new Promise<void>(async (resolve) => {
-		await fireEvent.mouseLeave(trigger);
-		await standby(1);
-		resolve();
-	});
+global._leave = async (trigger: Element) => {
+	await fireEvent.mouseLeave(trigger);
+	await standby(1);
+};
 
-global._enterAndLeave = async (trigger: Element) =>
-	new Promise<void>(async (resolve) => {
-		await _enter(trigger);
-		await _leave(trigger);
-		resolve();
-	});
+global._enterAndLeave = async (trigger: Element) => {
+	await _enter(trigger);
+	await _leave(trigger);
+};
 
-global._focus = async (trigger: Element) =>
-	new Promise<void>(async (resolve) => {
-		await fireEvent.focusIn(trigger);
-		await standby(1);
-		resolve();
-	});
+global._focus = async (trigger: Element) => {
+	await fireEvent.focusIn(trigger);
+	await standby(1);
+};
 
-global._blur = async (trigger: Element) =>
-	new Promise<void>(async (resolve) => {
-		await fireEvent.focusOut(trigger);
-		await standby(1);
-		resolve();
-	});
+global._blur = async (trigger: Element) => {
+	await fireEvent.focusOut(trigger);
+	await standby(1);
+};
 
-global._focusAndBlur = async (trigger: Element) =>
-	new Promise<void>(async (resolve) => {
-		await _focus(trigger);
-		await _blur(trigger);
-		resolve();
-	});
+global._focusAndBlur = async (trigger: Element) => {
+	await _focus(trigger);
+	await _blur(trigger);
+};
 
-global._keyDown = async (trigger: Element, key?: object) =>
-	new Promise<void>(async (resolve) => {
-		await fireEvent.keyDown(trigger, key || { key: 'Escape', code: 'Escape', charCode: 27 });
-		await standby(1);
-		resolve();
-	});
+global._keyDown = async (trigger: Element, key?: object) => {
+	await fireEvent.keyDown(trigger, key || { key: 'Escape', code: 'Escape', charCode: 27 });
+	await standby(1);
+};
 
-global._touchStart = async (trigger: Element) =>
-	new Promise<void>(async (resolve) => {
-		await fireEvent.touchStart(trigger);
-		await standby(1);
-		resolve();
-	});
+global._touchStart = async (trigger: Element) => {
+	await fireEvent.touchStart(trigger);
+	await standby(1);
+};
 
-global._touchEnd = async (trigger: Element) =>
-	new Promise<void>(async (resolve) => {
-		await fireEvent.touchEnd(trigger);
-		await standby(1);
-		resolve();
-	});
+global._touchEnd = async (trigger: Element) => {
+	await fireEvent.touchEnd(trigger);
+	await standby(1);
+};
 
-global._touchCancel = async (trigger: Element) =>
-	new Promise<void>(async (resolve) => {
-		await fireEvent.touchCancel(trigger);
-		await standby(1);
-		resolve();
-	});
+global._touchCancel = async (trigger: Element) => {
+	await fireEvent.touchCancel(trigger);
+	await standby(1);
+};


### PR DESCRIPTION
## Summary
All 10 test helpers in `vitest.setup.ts` used the `new Promise<void>(async (resolve) => { ... })` antipattern. Any rejection inside the executor would produce an unhandled rejection silently swallowed instead of surfacing as a test failure, leading to cryptic timeouts rather than meaningful assertion errors.

## Changes
- `vitest.setup.ts` — rewrite all 10 helpers (`_enter`, `_leave`, `_enterAndLeave`, `_focus`, `_blur`, `_focusAndBlur`, `_keyDown`, `_touchStart`, `_touchEnd`, `_touchCancel`) as plain `async` functions without the `new Promise` wrapper

## Test plan
- [ ] All 364 existing tests pass (`yarn test:ci`)
- [ ] Intentionally throwing inside a helper surfaces as a test failure rather than a timeout

Closes #198