### PR TITLE
chore: Remove stale test block from vite.config.ts

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,6 @@
-import { defineConfig } from 'vitest/config';
+import { defineConfig } from 'vite';
 import { sveltekit } from '@sveltejs/kit/vite';
 
 export default defineConfig({
-	plugins: [sveltekit()],
-
-	test: {
-		include: ['src/**/*.{test,spec}.{js,ts}']
-	}
+	plugins: [sveltekit()]
 });


### PR DESCRIPTION
## Summary
`vite.config.ts` contained a `test.include` block that was fully superseded by `vitest.config.ts`. Since Vitest picks up `vitest.config.ts` preferentially when it exists, the `test` block in `vite.config.ts` was dead configuration. The `defineConfig` import is also corrected from `vitest/config` to `vite`, clarifying the separation of responsibilities.

## Changes
- `vite.config.ts` — remove unused `test` block, update `defineConfig` import from `vitest/config` to `vite`

## Test plan
- [ ] All 364 existing tests pass (`yarn test:ci`), confirming `vitest.config.ts` remains the authoritative test config
- [ ] Build succeeds (`yarn build`)

Closes #199