### PR TITLE
chore: Add coverage thresholds to vitest.config.ts

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,7 +6,13 @@ export default defineConfig({
 		global: true,
 		environment: 'jsdom',
 		coverage: {
-			reporter: ['text', 'lcov']
+			reporter: ['text', 'lcov'],
+			thresholds: {
+				statements: 95,
+				branches: 90,
+				functions: 95,
+				lines: 95
+			}
 		},
 		setupFiles: ['./vitest.setup.ts']
 	},


### PR DESCRIPTION
## Summary
No coverage thresholds were configured, allowing coverage to silently drop between releases without failing CI. Thresholds are now set slightly below the current actual coverage to provide a meaningful safety net while leaving room for minor fluctuations.

## Changes
- `vitest.config.ts` — add `thresholds` to the `coverage` block: `statements: 95`, `branches: 90`, `functions: 95`, `lines: 95`

## Current coverage vs thresholds
| Metric | Threshold | Actual |
|---|---|---|
| Statements | 95% | 97.22% |
| Branches | 90% | 92.47% |
| Functions | 95% | 97.43% |
| Lines | 95% | 98.11% |

## Test plan
- [ ] `yarn test:ci` passes with thresholds enforced
- [ ] Verify CI fails when coverage drops below a threshold (manual spot-check or trust the config)

Closes #200