### PR TITLE
chore: Add engines field with minimum Node.js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,9 @@
 			"default": "./dist/index.js"
 		}
 	},
+	"engines": {
+		"node": ">=18.0.0"
+	},
 	"peerDependencies": {
 		"svelte": "^5.0.0"
 	},


### PR DESCRIPTION
## Summary
`package.json` had no `engines` field, making the minimum supported Node.js version invisible to consumers and CI pipelines. The minimum is set to `>=18.0.0`, which is the floor imposed by the Svelte 5 peer dependency. CI currently runs on Node 24.

## Changes
- `package.json` — add `"engines": { "node": ">=18.0.0" }`

## Test plan
- [ ] `yarn build` passes (includes `publint` validation)
- [ ] Verify consumers on Node < 18 get a clear warning from their package manager

Closes #201