### PR TITLE
test: Add test for onEnter callback with programmatic open

### DIFF
--- a/src/lib/__tests__/useTooltip.test.ts
+++ b/src/lib/__tests__/useTooltip.test.ts
@@ -1128,6 +1128,14 @@ describe('useTooltip', () => {
 			await standby(0);
 			expect(onEnter).toHaveBeenCalled();
 		});
+
+		test('Triggers callback when tooltip opens programmatically via open: true', async () => {
+			const onEnter = vi.fn(() => 0);
+			action = createAction(target, { ...options, onEnter });
+			action.update({ open: true });
+			await standby(1);
+			expect(onEnter).toHaveBeenCalled();
+		});
 	});
 
 	describe('useTooltip props: onLeave', () => {


### PR DESCRIPTION
## Summary
The `onEnter` callback had no test for the programmatic `open: true` path. The two existing tests covered mouse enter and update-after-init, but not the case where `open: true` is passed via `update()` to show the tooltip without user interaction.

Note: `onEnter` is only triggered through `update()`, not when `open: true` is set in the constructor — this is intentional and the test reflects the actual behavior.

## Changes
- `src/lib/__tests__/useTooltip.test.ts` — add test "Triggers callback when tooltip opens programmatically via open: true" in the `onEnter` describe block

## Test plan
- [ ] All 365 tests pass (`yarn test:ci`)
- [ ] New test verifies `onEnter` is called when `update({ open: true })` is called

Closes #203