### PR TITLE
docs: Fix leave animation in README basic usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ npm i @untemps/svelte-use-tooltip
 		containerClassName: `tooltip tooltip-right`,
 		animated: true,
 		animationEnterClassName: 'tooltip-enter',
+		animationLeaveClassName: 'tooltip-leave',
 		enterDelay: 100,
 		leaveDelay: 100,
 		offset: 20
@@ -111,6 +112,10 @@ npm i @untemps/svelte-use-tooltip
 
 	:global(.tooltip-enter) {
 		animation: fadeIn 0.2s linear forwards;
+	}
+
+	:global(.tooltip-leave) {
+		animation: fadeOut 0.2s linear forwards;
 	}
 
 	@keyframes fadeIn {


### PR DESCRIPTION
## Summary
The basic usage example in `README.md` defined a `@keyframes fadeOut` and an `animationEnterClassName` but never set `animationLeaveClassName`. Any user copy-pasting the example would see the enter animation but no leave animation, with no error to explain why.

## Changes
- `README.md` — add `animationLeaveClassName: 'tooltip-leave'` to the `use:useTooltip` props in the example
- `README.md` — add `:global(.tooltip-leave) { animation: fadeOut 0.2s linear forwards; }` CSS rule to match

## Test plan
- [ ] Copy-paste the updated example into a Svelte project and verify both enter and leave animations play correctly

Closes #202