### PR TITLE
test: Cover contentSelector matching no element in contentHasFocusableElements

### DIFF
--- a/src/lib/__tests__/useTooltip.test.ts
+++ b/src/lib/__tests__/useTooltip.test.ts
@@ -2026,6 +2026,14 @@ describe('useTooltip', () => {
 			expect(target).toHaveAttribute('tabindex', '-1');
 			target.removeAttribute('tabindex');
 		});
+
+		test('Does not apply tabindex when contentSelector matches no element', () => {
+			action = createAction(target, {
+				contentSelector: '#does-not-exist',
+				contentActions: { '*': { eventType: 'click', callback: vi.fn(), callbackParams: [] } }
+			});
+			expect(target).not.toHaveAttribute('tabindex');
+		});
 	});
 
 	describe('useTooltip dev warnings', () => {


### PR DESCRIPTION
## Summary

The `if (!el) return false` early-return branch in `#contentHasFocusableElements()` was unreachable in tests — triggered when `contentSelector` points to a selector that matches nothing in the DOM. This adds one test that covers that path.

## Changes

- `src/lib/__tests__/useTooltip.test.ts` — new test in the `useTooltip tabindex` block: creates a tooltip with `contentSelector: '#does-not-exist'` and `contentActions`, then asserts `tabindex` is not applied to the trigger

## Test plan

- [ ] 385 tests pass (`yarn test:ci`)
- [ ] Branch coverage on `Tooltip.ts` improves

Closes #217