### PR TITLE
test: Cover falsy fallback for animation class names in update()

### DIFF
--- a/src/lib/__tests__/useTooltip.test.ts
+++ b/src/lib/__tests__/useTooltip.test.ts
@@ -1268,6 +1268,20 @@ describe('useTooltip', () => {
 			expect(content).not.toBeInTheDocument();
 		});
 
+		test('Falls back to __tooltip-enter when animationEnterClassName is reset to empty string via update', async () => {
+			action = createAction(target, { ...options, animated: true, animationEnterClassName: 'my-enter' });
+			action.update({ ...options, animated: true, animationEnterClassName: '' });
+			await _enter(target);
+			expect(tooltipEl()).toHaveClass('__tooltip-enter');
+		});
+
+		test('Falls back to __tooltip-leave when animationLeaveClassName is reset to empty string via update', async () => {
+			action = createAction(target, { ...options, animated: true, animationLeaveClassName: 'my-leave' });
+			action.update({ ...options, animated: true, animationLeaveClassName: '' });
+			await _enterAndLeave(target);
+			expect(tooltipEl()).toHaveClass('__tooltip-leave');
+		});
+
 		test('Cancels animation timeout on destroy and removes tooltip immediately', async () => {
 			vi.useFakeTimers();
 			try {


### PR DESCRIPTION
## Summary

The `|| '__tooltip-enter'` and `|| '__tooltip-leave'` fallback arms in `#applyState()` were never reached in tests — only triggered when a defined but falsy value (e.g. `''`) is passed for `animationEnterClassName` or `animationLeaveClassName` via `update()`. Two tests cover these paths.

## Changes

- `src/lib/__tests__/useTooltip.test.ts` — 2 new tests in the `useTooltip props: animated` block:
  - Init with a custom enter class name, reset to `''` via `update()`, assert `__tooltip-enter` is applied on show
  - Init with a custom leave class name, reset to `''` via `update()`, assert `__tooltip-leave` is applied on hide

## Test plan

- [ ] 387 tests pass (`yarn test:ci`)
- [ ] Branch coverage on `Tooltip.ts` improves from 92.36% to 94.21%

Closes #218