### PR TITLE
test: Cover window change handler guard with no active tooltip

### DIFF
--- a/src/lib/__tests__/useTooltip.test.ts
+++ b/src/lib/__tests__/useTooltip.test.ts
@@ -218,6 +218,13 @@ describe('useTooltip', () => {
 			spy.mockRestore();
 		});
 
+		test('Does not throw when window resize fires with no active tooltip', async () => {
+			action = createAction(target, options);
+			// Tooltip is not shown — parentNode guard must swallow the event silently
+			await expect(fireEvent.resize(window)).resolves.not.toThrow();
+			expect(getElement('#content')).not.toBeInTheDocument();
+		});
+
 		test('Removes ancestor scroll listeners on destroy', async () => {
 			const container = createElement({
 				tag: 'div',


### PR DESCRIPTION
## Summary

Adds a test that fires a `resize` event on `window` while the tooltip is not shown, exercising the `!this.#tooltip || !this.#tooltip.parentNode` early-return guard in `#onWindowChange()` (line 984). This path was previously unreachable by the test suite.

## Changes

- `src/lib/__tests__/useTooltip.test.ts` — add `Does not throw when window resize fires with no active tooltip` test

## Test plan

- [ ] Create tooltip without opening it
- [ ] Fire `window` resize event
- [ ] Verify no error thrown
- [ ] Verify tooltip remains hidden

Closes #220